### PR TITLE
set focus to password entry widget

### DIFF
--- a/kano_greeter/greeter_window.py
+++ b/kano_greeter/greeter_window.py
@@ -80,6 +80,7 @@ class GreeterWindow(ApplicationWindow):
         password_view = PasswordView(user)
         self.set_main(password_view)
         self.top_bar.enable_prev()
+        password_view.grab_focus()
 
     def _back_cb(self, event, button):
         self.go_to_users()

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -102,6 +102,9 @@ class PasswordView(Gtk.Grid):
                            parent_window=self.get_toplevel())
         error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
         error.run()
+    
+    def grab_focus(self):
+        self.password.grab_focus()
 
     def delete_user(self, *_):
         import pam


### PR DESCRIPTION
Makes `kano-greeter` a tiny bit more keyboard-friendly.