### PR TITLE
allow focus for user list

### DIFF
--- a/kano_greeter/last_user.py
+++ b/kano_greeter/last_user.py
@@ -2,7 +2,7 @@
 
 import os
 
-LAST_USER_PATH = '/var/lib/kano-greeter'
+LAST_USER_PATH = '/var/lib/lightdm/.cache/kano-greeter'
 LAST_USER_FILE = os.path.join(LAST_USER_PATH, 'last-user')
 
 def get_last_user():

--- a/kano_greeter/last_user.py
+++ b/kano_greeter/last_user.py
@@ -2,14 +2,13 @@
 
 import os
 
-LAST_USER_PATH = '/var/lib/lightdm/.cache/kano-greeter/'
-LAST_USER_FILE = 'last-user'
+LAST_USER_PATH = '/var/lib/kano-greeter'
+LAST_USER_FILE = os.path.join(LAST_USER_PATH, 'last-user')
 
 def get_last_user():
     try:
-        with open(os.path.join(LAST_USER_PATH, LAST_USER_FILE)) as f:
-            last_user = f.read()
-            f.close()
+        with open(LAST_USER_FILE) as f:
+            last_user = f.readline().strip()
     except:
         last_user = None
     return last_user
@@ -17,6 +16,6 @@ def get_last_user():
 def set_last_user(last_user):
     if not os.path.exists(LAST_USER_PATH):
         os.makedirs(LAST_USER_PATH)
-    f = open(os.path.join(LAST_USER_PATH, LAST_USER_FILE), "w+")
-    f.write(last_user)
-    f.close()
+    with open(LAST_USER_FILE, 'w+') as f:
+        f.write(last_user)
+        f.write('\n')

--- a/kano_greeter/last_user.py
+++ b/kano_greeter/last_user.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+
+LAST_USER_PATH = '/var/lib/lightdm/.cache/kano-greeter/'
+LAST_USER_FILE = 'last-user'
+
+def get_last_user():
+    try:
+        with open(os.path.join(LAST_USER_PATH, LAST_USER_FILE)) as f:
+            last_user = f.read()
+            f.close()
+    except:
+        last_user = None
+    return last_user
+
+def set_last_user(last_user):
+    if not os.path.exists(LAST_USER_PATH):
+        os.makedirs(LAST_USER_PATH)
+    f = open(os.path.join(LAST_USER_PATH, LAST_USER_FILE), "w+")
+    f.write(last_user)
+    f.close()

--- a/kano_greeter/media/css/kano-greeter.css
+++ b/kano_greeter/media/css/kano-greeter.css
@@ -1,7 +1,3 @@
 GtkLabel.login {
     font: Bariol Bold 13;
 }
-
-.user GtkLabel {
-    font: Bariol Bold 18;
-}

--- a/kano_greeter/media/css/kano-greeter.css
+++ b/kano_greeter/media/css/kano-greeter.css
@@ -1,21 +1,3 @@
-GtkLabel {
-    font: Bariol 18;
-    font-weight: bold;
-}
-
-GtkEventBox.user {
-    background: @kano_orange;
-    border-width: 3px;
-    border-radius:3px;
-    padding: 12px;
-}
-
-GtkEventBox.user GtkLabel {
-    color: #ffffff;
-}
-
-GtkEventBox.user.hover {
-    background: @kano_orange_lighter;
-    border-color: @active_border;
-    border-style: solid;
+.user GtkLabel {
+    font: Bariol Bold 18;
 }

--- a/kano_greeter/media/css/kano-greeter.css
+++ b/kano_greeter/media/css/kano-greeter.css
@@ -1,3 +1,7 @@
+GtkLabel.login {
+    font: Bariol Bold 13;
+}
+
 .user GtkLabel {
     font: Bariol Bold 18;
 }

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -16,6 +16,7 @@ from kano.gtk3.buttons import KanoButton, OrangeButton
 from kano.gtk3.heading import Heading
 from kano.gtk3.kano_dialog import KanoDialog
 
+from kano_greeter.last_user import set_last_user
 
 class PasswordView(Gtk.Grid):
     greeter = LightDM.Greeter()
@@ -86,6 +87,8 @@ class PasswordView(Gtk.Grid):
             'The user {} is authenticated. Starting LightDM X Session'
             .format(self.user))
 
+        set_last_user(self.user)
+        
         if not _greeter.start_session_sync('lightdm-xsession'):
             logger.error('Failed to start session')
         else:

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -88,7 +88,7 @@ class PasswordView(Gtk.Grid):
             .format(self.user))
 
         set_last_user(self.user)
-        
+
         if not _greeter.start_session_sync('lightdm-xsession'):
             logger.error('Failed to start session')
         else:
@@ -105,7 +105,7 @@ class PasswordView(Gtk.Grid):
                            parent_window=self.get_toplevel())
         error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
         error.run()
-    
+
     def grab_focus(self):
         self.password.grab_focus()
 

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -41,11 +41,11 @@ class PasswordView(Gtk.Grid):
         self.attach(self.password, 0, 1, 1, 1)
 
         self.login_btn = KanoButton('LOGIN')
-        self.login_btn.connect('button-release-event', self._login_cb)
+        self.login_btn.connect('clicked', self._login_cb)
         self.attach(self.login_btn, 0, 2, 1, 1)
 
         delete_account_btn = OrangeButton('Remove Account')
-        delete_account_btn.connect('button-release-event', self.delete_user)
+        delete_account_btn.connect('clicked', self.delete_user)
         self.attach(delete_account_btn, 0, 3, 1, 1)
 
     def _reset_greeter(self):

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -34,19 +34,22 @@ class PasswordView(Gtk.Grid):
                         'If you haven\'t changed your password,\n'
                         'use "kano"')
         self.attach(title.container, 0, 0, 1, 1)
+        self.label = Gtk.Label(user)
+        self.label.get_style_context().add_class('login')
+        self.attach(self.label, 0, 1, 1, 1)
         self.password = Gtk.Entry()
         self.password.set_visibility(False)
         self.password.set_alignment(0.5)
         self.password.connect('activate', self._login_cb)
-        self.attach(self.password, 0, 1, 1, 1)
+        self.attach(self.password, 0, 2, 1, 1)
 
         self.login_btn = KanoButton('LOGIN')
         self.login_btn.connect('clicked', self._login_cb)
-        self.attach(self.login_btn, 0, 2, 1, 1)
+        self.attach(self.login_btn, 0, 3, 1, 1)
 
         delete_account_btn = OrangeButton('Remove Account')
         delete_account_btn.connect('clicked', self.delete_user)
-        self.attach(delete_account_btn, 0, 3, 1, 1)
+        self.attach(delete_account_btn, 0, 4, 1, 1)
 
     def _reset_greeter(self):
         PasswordView.greeter = PasswordView.greeter.new()

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -81,7 +81,6 @@ class User(KanoButton):
     def __init__(self, username):
         KanoButton.__init__(self, text=username.title(), color='orange')
         self.set_size_request(-1, self.HEIGHT)
-        self.get_style_context().add_class('user')
 
         self.username = username
         self.connect('clicked', self._user_select_cb)

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -36,7 +36,7 @@ class UserList(ScrolledWindow):
 
         title = Heading('Select Account', 'Log in to which account?')
         self.box.pack_start(title.container, False, False, 0)
-        
+
         self.last_username = get_last_user()
 
         self._populate()
@@ -79,7 +79,7 @@ class User(KanoButton):
     HEIGHT = 50
 
     def __init__(self, username):
-        KanoButton.__init__(self, text=username.title(), color="orange")
+        KanoButton.__init__(self, text=username.title(), color='orange')
         self.set_size_request(-1, self.HEIGHT)
         self.get_style_context().add_class('user')
 

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -14,7 +14,7 @@ import os
 from kano.logging import logger
 from kano.gtk3.scrolled_window import ScrolledWindow
 from kano.gtk3.heading import Heading
-from kano.gtk3.buttons import OrangeButton
+from kano.gtk3.buttons import OrangeButton, KanoButton
 from kano.gtk3.kano_dialog import KanoDialog
 
 
@@ -70,32 +70,23 @@ class UserList(ScrolledWindow):
 
 
 
-class User(Gtk.EventBox):
+class User(KanoButton):
     HEIGHT = 50
 
     def __init__(self, username):
-        Gtk.EventBox.__init__(self)
+        KanoButton.__init__(self, text=username.title(), color="orange")
         self.set_size_request(-1, self.HEIGHT)
+        self.get_style_context().add_class('user')
 
         self.username = username
 
-        self.get_style_context().add_class('user')
-
-        label = Gtk.Label(username.title())
-        self.add(label)
-
         self.connect('button-release-event', self._user_select_cb)
-        self.connect('enter-notify-event', self._hover_cb)
-        self.connect('leave-notify-event', self._unhover_cb)
+        self.connect('key-release-event', self._user_select_cb)
 
     def _user_select_cb(self, button, event):
-        logger.debug('user {} selected'.format(self.username))
+         # 65293 is the ENTER keycode
+        if not hasattr(event, 'keyval') or event.keyval == 65293:
+            logger.debug('user {} selected'.format(self.username))
+            win = self.get_toplevel()
+            win.go_to_password(self.username)
 
-        win = self.get_toplevel()
-        win.go_to_password(self.username)
-
-    def _hover_cb(self, widget, event):
-        self.get_style_context().add_class('hover')
-
-    def _unhover_cb(self, widget, event):
-        self.get_style_context().remove_class('hover')

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -17,6 +17,7 @@ from kano.gtk3.heading import Heading
 from kano.gtk3.buttons import OrangeButton, KanoButton
 from kano.gtk3.kano_dialog import KanoDialog
 
+from kano_greeter.last_user import get_last_user
 
 class UserList(ScrolledWindow):
     HEIGHT = 300
@@ -35,6 +36,8 @@ class UserList(ScrolledWindow):
 
         title = Heading('Select Account', 'Log in to which account?')
         self.box.pack_start(title.container, False, False, 0)
+        
+        self.last_username = get_last_user()
 
         self._populate()
 
@@ -52,6 +55,8 @@ class UserList(ScrolledWindow):
     def add_item(self, username):
         user = User(username)
         self.box.pack_start(user, False, False, 0)
+        if username == self.last_username:
+            user.grab_focus()
 
     @staticmethod
     def add_account(*_):

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -79,14 +79,10 @@ class User(KanoButton):
         self.get_style_context().add_class('user')
 
         self.username = username
+        self.connect('clicked', self._user_select_cb)
 
-        self.connect('button-release-event', self._user_select_cb)
-        self.connect('key-release-event', self._user_select_cb)
-
-    def _user_select_cb(self, button, event):
-         # 65293 is the ENTER keycode
-        if not hasattr(event, 'keyval') or event.keyval == 65293:
-            logger.debug('user {} selected'.format(self.username))
-            win = self.get_toplevel()
-            win.go_to_password(self.username)
+    def _user_select_cb(self, button):
+        logger.debug('user {} selected'.format(self.username))
+        win = self.get_toplevel()
+        win.go_to_password(self.username)
 

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -42,7 +42,7 @@ class UserList(ScrolledWindow):
         self._populate()
 
         add_account_btn = OrangeButton('Add Account')
-        add_account_btn.connect('button-release-event', self.add_account)
+        add_account_btn.connect('clicked', self.add_account)
         self.box.pack_start(add_account_btn, False, False, 0)
 
     def _populate(self):


### PR DESCRIPTION
In `user_list.py`, this replaces the EventBox widget with a KanoButton widget.

By doing this, `kano-greeter` gains keyboard focus for the user list, making the login process easier to use without a mouse.

**BUT: There is still one bug** I couldn't resolve today and that's why this PR is still incomplete.

The font setting for the CSS rule `.user GtkLabel` is being ignored and Gtk shows the default CSS font setting for KanoButton instead (Bariol 13, I guess?).

The CSS rule is okay: adding `background: green;` to the rule will paint the GtkLabel green, so it *is* the right CSS path.

Fiddled around with the CSS but no success, Gtk CSS is strange. Any idea about how to define the font size in the CSS file so that Gtk actually applies it? Thanks.