### PR TITLE
I18n gettext hooks for kano-greeter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.mo
+po/messages.pot

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -41,6 +41,24 @@ If you added new message strings or made changes to existing ones, do `make mess
 
 After that, merge the existing translations with `make update` and ask your translators to update their translations.
 
+## gettext explained (in 20 seconds)
+
+* User-visible strings in the source are marked with a macro of your choice. Usually, it's `_()`.
+* `xgettext` extracts these message strings from your sources and puts them into a template file.
+* This template file, usually named `messages.pot`, contains all user-visible strings of the project, but no translations.
+* Translators use `msginit` to copy the template file into a new *portable object* file for their language (explained above).
+* The translations are put into `<lang>.po`. It's a plain-text file format, you can use any text editor.
+* More convenient, specialized `.po`-editors and web-based tools such as Pootle exist, as well.
+* If your template file changes, use `msgmerge` to merge your existing translations with the new template, then re-translate the updated messages. Beware of `msgmerge`'s "fuzzy" matches.
+* `msgfmt` converts a `.po` file into a binary *message object* file.
+* You don't link these `.mo` files with your application binary.
+* The `.mo` files are bundled alongside with your software as part of the distribution package.
+* During installation, the `.mo` files are copied into the system's locale directory, usually `/usr/share/locale`.
+* On startup, your application will look for the message object file that it needs for the current system locale.
+* The locale even allows you to provide region-specific translations, e.g. "colour" for en_UK vs "color" for en_US.
+* At runtime, all user-visible strings are being replaced with the translations.
+* If no message object was found for the system locale, the original strings will be shown. 
+
 ## To-Do
 
 Pootle or Transifex integration.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,46 @@
+# Translation
+
+Translation files are found in the `po/` directory.
+
+## i18n not released yet
+
+Kano OS is not fully i18n-aware and locales are not installed for end users, yet. You can translate this application, but as of now, users will still see the default English message strings.
+
+## How to add a new translation
+
+In this example, we're going to add a French translation:
+
+    # install your target locale `fr_FR.utf8` with:
+    sudo dpkg-reconfigure locales
+    
+    cd po/
+    # create messages.pot
+    make messages
+    
+    # create fr.po from messages.pot:
+    msginit -l fr_FR.utf8
+    
+    # now use your favourite editor to translate fr.po
+    
+    # build locale files:
+    make
+    
+    cd ..
+
+    # prepare for testing as described in [README](README.md),
+    # then change this in /usr/share/xgreeters/kano-greeter-devel.desktop
+    Exec=dash -c "LC_ALL=fr_FR.utf8 /path/to/repo/bin/kano-greeter"
+    
+    # run test as in described in [README](README.md),
+
+## How to make sure your code is i18n-aware
+
+Add the gettext `_()` macro to all the user-visible message strings in your Python. List the Python source files that contain message strings in `PYPOTFILES`.
+
+If you added new message strings or made changes to existing ones, do `make messages` to keep the template file up-to-date.
+
+After that, merge the existing translations with `make update` and ask your translators to update their translations.
+
+## To-Do
+
+Pootle or Transifex integration.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -27,11 +27,11 @@ In this example, we're going to add a French translation:
     
     cd ..
 
-    # prepare for testing as described in [README](README.md),
+    # prepare for testing as described in README.md
     # then change this in /usr/share/xgreeters/kano-greeter-devel.desktop
     Exec=dash -c "LC_ALL=fr_FR.utf8 /path/to/repo/bin/kano-greeter"
     
-    # run test as in described in [README](README.md),
+    # run test as in described in README.md
 
 ## How to make sure your code is i18n-aware
 

--- a/bin/kano-greeter
+++ b/bin/kano-greeter
@@ -9,6 +9,7 @@
 from gi.repository import Gtk
 import os
 import sys
+import gettext
 
 from kano.gtk3.apply_styles import apply_styling_to_screen
 
@@ -17,6 +18,11 @@ if __name__ == '__main__' and __package__ is None:
 
     if not DIR_PATH.startswith('/usr'):
         sys.path.insert(1, DIR_PATH)
+        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+    else:
+        LOCALE_PATH = None
+
+gettext.install('kano-greeter', LOCALE_PATH, unicode=1)
 
 from kano.logging import logger
 from kano_greeter.paths import CSS_PATH

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0), python-setuptools
+Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext
 
 Package: kano-greeter
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,5 @@
 #!/usr/bin/make -f
 
 %:
+	cd po && make
 	dh $@ --with python2

--- a/kano_greeter/greeter_window.py
+++ b/kano_greeter/greeter_window.py
@@ -28,7 +28,7 @@ class GreeterWindow(ApplicationWindow):
     def __init__(self):
         apply_common_to_screen()
 
-        ApplicationWindow.__init__(self, 'Login', self.WIDTH, self.HEIGHT)
+        ApplicationWindow.__init__(self, _('Login'), self.WIDTH, self.HEIGHT)
         self.connect("delete-event", Gtk.main_quit)
 
         self.grid = Gtk.Grid()
@@ -37,12 +37,12 @@ class GreeterWindow(ApplicationWindow):
         self.grid.set_column_spacing(30)
         self.grid.set_row_spacing(30)
 
-        self.top_bar = TopBar('Login')
+        self.top_bar = TopBar(_('Login'))
         self._remove_top_bar_buttons()
         self.top_bar.set_size_request(self.WIDTH, -1)
         self.grid.attach(self.top_bar, 0, 0, 3, 1)
 
-        self.shutdown_btn = OrangeButton('Shutdown')
+        self.shutdown_btn = OrangeButton(_('Shutdown'))
         self.shutdown_btn.connect('clicked', self.shutdown)
         align = Gtk.Alignment(xalign=1.0,
                               xscale=0.0)
@@ -86,12 +86,20 @@ class GreeterWindow(ApplicationWindow):
         self.go_to_users()
 
     @staticmethod
-    def shutdown(*_):
-        confirm = KanoDialog(title_text='Are you sure you want to shut down?',
-                             button_dict={
-                                 'OK': {'return_value': True},
-                                 'CANCEL': {'return_value': False}
-                             })
+    def shutdown(*args):
+        confirm = KanoDialog(title_text = _('Are you sure you want to shut down?'),
+                             button_dict= [
+                                {
+                                    'label': _('Cancel').upper(),
+                                    'color': 'red',
+                                    'return_value': False
+                                },
+                                {
+                                    'label': _('OK').upper(),
+                                    'color': 'green',
+                                    'return_value': True
+                                }
+                             ])
         confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
         if confirm.run():

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -29,9 +29,9 @@ class PasswordView(Gtk.Grid):
         self._reset_greeter()
 
         self.user = user
-        title = Heading('Enter your password',
-                        'If you haven\'t changed your password,\n'
-                        'use "kano"')
+        title = Heading(_('Enter your password'),
+                        _('If you haven\'t changed your password,\n'
+                        'use "kano"'))
         self.attach(title.container, 0, 0, 1, 1)
         self.password = Gtk.Entry()
         self.password.set_visibility(False)
@@ -39,11 +39,11 @@ class PasswordView(Gtk.Grid):
         self.password.connect('activate', self._login_cb)
         self.attach(self.password, 0, 1, 1, 1)
 
-        self.login_btn = KanoButton('LOGIN')
+        self.login_btn = KanoButton(_('Login').upper())
         self.login_btn.connect('button-release-event', self._login_cb)
         self.attach(self.login_btn, 0, 2, 1, 1)
 
-        delete_account_btn = OrangeButton('Remove Account')
+        delete_account_btn = OrangeButton(_('Remove Account'))
         delete_account_btn.connect('button-release-event', self.delete_user)
         self.attach(delete_account_btn, 0, 3, 1, 1)
 
@@ -78,7 +78,7 @@ class PasswordView(Gtk.Grid):
 
         if not _greeter.get_is_authenticated():
             logger.warn('Could not authenticate user {}'.format(self.user))
-            self._auth_error_cb('Incorrect password (The default is "kano")')
+            self._auth_error_cb(_('Incorrect password (The default is "kano")'))
 
             return
 
@@ -97,7 +97,7 @@ class PasswordView(Gtk.Grid):
         win = self.get_toplevel()
         win.go_to_users()
 
-        error = KanoDialog(title_text='Error Logging In',
+        error = KanoDialog(title_text=_('Error Logging In'),
                            description_text=text,
                            parent_window=self.get_toplevel())
         error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
@@ -106,7 +106,7 @@ class PasswordView(Gtk.Grid):
     def grab_focus(self):
         self.password.grab_focus()
 
-    def delete_user(self, *_):
+    def delete_user(self, *args):
         import pam
 
         password_input = Gtk.Entry()
@@ -114,14 +114,21 @@ class PasswordView(Gtk.Grid):
         password_input.set_alignment(0.5)
 
         confirm = KanoDialog(
-            title_text='Are you sure you want to delete {}\'s account?'.format(
-                self.user),
-            description_text='A reboot will be required',
+            title_text = _('Are you sure you want to delete {}\'s account?').format(self.user),
+            description_text = _('A reboot will be required'),
             widget=password_input,
-            button_dict={
-                'DELETE': {'return_value': True},
-                'CANCEL': {'return_value': False}
-            })
+            button_dict = [
+                {
+                    'label': _('Cancel').upper(),
+                    'color': 'red',
+                    'return_value': False
+                },
+                {
+                    'label': _('Delete').upper(),
+                    'color': 'green',
+                    'return_value': True
+                }
+            ])
         confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
         if not confirm.run():
@@ -133,6 +140,6 @@ class PasswordView(Gtk.Grid):
             os.system('sudo kano-init deleteuser {}'.format(self.user))
             LightDM.restart()
         else:
-            error = KanoDialog(title_text='Incorrect password')
+            error = KanoDialog(title_text = _('Incorrect password'))
             error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
             error.run()

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -33,12 +33,12 @@ class UserList(ScrolledWindow):
         self.box.set_spacing(10)
         self.add(self.box)
 
-        title = Heading('Select Account', 'Log in to which account?')
+        title = Heading(_('Select Account'), _('Log in to which account?'))
         self.box.pack_start(title.container, False, False, 0)
 
         self._populate()
 
-        add_account_btn = OrangeButton('Add Account')
+        add_account_btn = OrangeButton(_('Add Account'))
         add_account_btn.connect('button-release-event', self.add_account)
         self.box.pack_start(add_account_btn, False, False, 0)
 
@@ -54,14 +54,22 @@ class UserList(ScrolledWindow):
         self.box.pack_start(user, False, False, 0)
 
     @staticmethod
-    def add_account(*_):
+    def add_account(*args):
         confirm = KanoDialog(
-            title_text='Are you sure you want to create a new account?',
-            description_text='A reboot will be required',
-            button_dict={
-                'CREATE': {'return_value': True},
-                'CANCEL': {'return_value': False}
-            })
+            title_text = _('Are you sure you want to create a new account?'),
+            description_text = _('A reboot will be required'),
+            button_dict = [
+                {
+                    'label': _('Cancel').upper(),
+                    'color': 'red',
+                    'return_value': False
+                },
+                {
+                    'label': _('Create').upper(),
+                    'color': 'green',
+                    'return_value': True
+                }
+            ])
         confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
 
         if confirm.run():

--- a/po/Makefile
+++ b/po/Makefile
@@ -3,15 +3,17 @@ APPNAME=kano-greeter
 MSGLANGS=$(notdir $(wildcard *po))
 MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
 
-.PHONY: clean messages
+.PHONY: clean_locales messages
 
 build: $(MSGOBJS)
 
 update: $(MSGLANGS)
 
-clean:
-	rm -f messages.pot
+clean_locales:
 	rm -rf ../locale
+
+clean: clean_locales
+	rm -f messages.pot
 
 define run-xgettext
 xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
@@ -27,6 +29,6 @@ messages.pot:
 	msgmerge -N -U $*.po messages.pot
 	touch $*.po
 
-../locale/%/LC_MESSAGES/$(APPNAME).mo: %.po
+../locale/%/LC_MESSAGES/$(APPNAME).mo: clean_locales
 	mkdir -p $(dir $@)
 	msgfmt -c -o $@ $*.po

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,0 +1,32 @@
+APPNAME=kano-greeter
+
+MSGLANGS=$(notdir $(wildcard *po))
+MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
+
+.PHONY: clean messages
+
+build: $(MSGOBJS)
+
+update: $(MSGLANGS)
+
+clean:
+	rm -f messages.pot
+	rm -rf ../locale
+
+define run-xgettext
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
+endef
+
+messages:
+	$(run-xgettext)
+
+messages.pot:
+	$(run-xgettext)
+
+%.po: messages.pot
+	msgmerge -N -U $*.po messages.pot
+	touch $*.po
+
+../locale/%/LC_MESSAGES/$(APPNAME).mo: %.po
+	mkdir -p $(dir $@)
+	msgfmt -c -o $@ $*.po

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,4 +1,5 @@
 APPNAME=kano-greeter
+ORG="Kano Computing Ltd."
 
 MSGLANGS=$(notdir $(wildcard *po))
 MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
@@ -16,7 +17,8 @@ clean: clean_locales
 	rm -f messages.pot
 
 define run-xgettext
-xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
 endef
 
 messages:

--- a/po/PYPOTFILES
+++ b/po/PYPOTFILES
@@ -1,0 +1,4 @@
+../bin/kano-greeter
+../kano_greeter/greeter_window.py
+../kano_greeter/password_view.py
+../kano_greeter/user_list.py

--- a/po/de.po
+++ b/po/de.po
@@ -1,14 +1,14 @@
-# German translations for PACKAGE package
-# German messages for PACKAGE.
-# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# German translations for kano-greeter package
+# German messages for kano-greeter.
+# Copyright (C) 2015 Kano Computing Ltd.
+# This file is distributed under the same license as the kano-greeter package.
 #  <kontakt@hanno.de>, 2015.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: kano-greeter\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-18 10:24+0100\n"
+"POT-Creation-Date: 2015-03-06 09:53+0100\n"
 "PO-Revision-Date: 2015-02-17 15:11+0100\n"
 "Last-Translator:  <kontakt@hanno.de>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../kano_greeter/greeter_window.py:31 ../kano_greeter/greeter_window.py:40
-#: ../kano_greeter/password_view.py:42
+#: ../kano_greeter/password_view.py:46
 msgid "Login"
 msgstr "Anmelden"
 
@@ -31,20 +31,20 @@ msgstr "Herunterfahren"
 msgid "Are you sure you want to shut down?"
 msgstr "Wirklich das System herunterfahren?"
 
-#: ../kano_greeter/greeter_window.py:92
-msgid "OK"
-msgstr "OK"
-
-#: ../kano_greeter/greeter_window.py:93 ../kano_greeter/password_view.py:122
-#: ../kano_greeter/user_list.py:63
+#: ../kano_greeter/greeter_window.py:93 ../kano_greeter/password_view.py:128
+#: ../kano_greeter/user_list.py:68
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: ../kano_greeter/password_view.py:32
+#: ../kano_greeter/greeter_window.py:98
+msgid "OK"
+msgstr "OK"
+
+#: ../kano_greeter/password_view.py:33
 msgid "Enter your password"
 msgstr "Passwort eingeben"
 
-#: ../kano_greeter/password_view.py:33
+#: ../kano_greeter/password_view.py:34
 msgid ""
 "If you haven't changed your password,\n"
 "use \"kano\""
@@ -52,50 +52,50 @@ msgstr ""
 "Falls Du Dein Passwort nicht geändert hast,\n"
 "ist \"kano\" voreingestellt."
 
-#: ../kano_greeter/password_view.py:46
+#: ../kano_greeter/password_view.py:50
 msgid "Remove Account"
 msgstr "Nutzerkonto löschen"
 
-#: ../kano_greeter/password_view.py:81
+#: ../kano_greeter/password_view.py:85
 msgid "Incorrect password (The default is \"kano\")"
 msgstr "Falsches Passwort (voreingestellt ist \"kano\")"
 
-#: ../kano_greeter/password_view.py:100
+#: ../kano_greeter/password_view.py:106
 msgid "Error Logging In"
 msgstr "Fehler bei Anmeldung"
 
-#: ../kano_greeter/password_view.py:117
+#: ../kano_greeter/password_view.py:123
 msgid "Are you sure you want to delete {}'s account?"
 msgstr "Willst Du wirklich das Konto von {} löschen?"
 
-#: ../kano_greeter/password_view.py:118 ../kano_greeter/user_list.py:60
+#: ../kano_greeter/password_view.py:124 ../kano_greeter/user_list.py:65
 msgid "A reboot will be required"
 msgstr "Danach wird das System neu gestartet"
 
-#: ../kano_greeter/password_view.py:127
+#: ../kano_greeter/password_view.py:133
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../kano_greeter/password_view.py:143
+#: ../kano_greeter/password_view.py:149
 msgid "Incorrect password"
 msgstr "Falsches Passwort"
 
-#: ../kano_greeter/user_list.py:36
+#: ../kano_greeter/user_list.py:37
 msgid "Select Account"
 msgstr "Nutzerkonto auswählen"
 
-#: ../kano_greeter/user_list.py:36
+#: ../kano_greeter/user_list.py:37
 msgid "Log in to which account?"
 msgstr "Welchen Nutzer einloggen?"
 
-#: ../kano_greeter/user_list.py:41
+#: ../kano_greeter/user_list.py:44
 msgid "Add Account"
 msgstr "Nutzerkonto hinzufügen"
 
-#: ../kano_greeter/user_list.py:59
+#: ../kano_greeter/user_list.py:64
 msgid "Are you sure you want to create a new account?"
 msgstr "Willst Du wirklich ein neues Nutzerkonto anlegen?"
 
-#: ../kano_greeter/user_list.py:68
+#: ../kano_greeter/user_list.py:73
 msgid "Create"
 msgstr "Anlegen"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,101 @@
+# German translations for PACKAGE package
+# German messages for PACKAGE.
+# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#  <kontakt@hanno.de>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-18 10:24+0100\n"
+"PO-Revision-Date: 2015-02-17 15:11+0100\n"
+"Last-Translator:  <kontakt@hanno.de>\n"
+"Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../kano_greeter/greeter_window.py:31 ../kano_greeter/greeter_window.py:40
+#: ../kano_greeter/password_view.py:42
+msgid "Login"
+msgstr "Anmelden"
+
+#: ../kano_greeter/greeter_window.py:45
+msgid "Shutdown"
+msgstr "Herunterfahren"
+
+#: ../kano_greeter/greeter_window.py:90
+msgid "Are you sure you want to shut down?"
+msgstr "Wirklich das System herunterfahren?"
+
+#: ../kano_greeter/greeter_window.py:92
+msgid "OK"
+msgstr "OK"
+
+#: ../kano_greeter/greeter_window.py:93 ../kano_greeter/password_view.py:122
+#: ../kano_greeter/user_list.py:63
+msgid "Cancel"
+msgstr "Abbruch"
+
+#: ../kano_greeter/password_view.py:32
+msgid "Enter your password"
+msgstr "Passwort eingeben"
+
+#: ../kano_greeter/password_view.py:33
+msgid ""
+"If you haven't changed your password,\n"
+"use \"kano\""
+msgstr ""
+"Falls Du Dein Passwort nicht geändert hast,\n"
+"ist \"kano\" voreingestellt."
+
+#: ../kano_greeter/password_view.py:46
+msgid "Remove Account"
+msgstr "Nutzerkonto löschen"
+
+#: ../kano_greeter/password_view.py:81
+msgid "Incorrect password (The default is \"kano\")"
+msgstr "Falsches Passwort (voreingestellt ist \"kano\")"
+
+#: ../kano_greeter/password_view.py:100
+msgid "Error Logging In"
+msgstr "Fehler bei Anmeldung"
+
+#: ../kano_greeter/password_view.py:117
+msgid "Are you sure you want to delete {}'s account?"
+msgstr "Willst Du wirklich das Konto von {} löschen?"
+
+#: ../kano_greeter/password_view.py:118 ../kano_greeter/user_list.py:60
+msgid "A reboot will be required"
+msgstr "Danach wird das System neu gestartet"
+
+#: ../kano_greeter/password_view.py:127
+msgid "Delete"
+msgstr "Löschen"
+
+#: ../kano_greeter/password_view.py:143
+msgid "Incorrect password"
+msgstr "Falsches Passwort"
+
+#: ../kano_greeter/user_list.py:36
+msgid "Select Account"
+msgstr "Nutzerkonto auswählen"
+
+#: ../kano_greeter/user_list.py:36
+msgid "Log in to which account?"
+msgstr "Welchen Nutzer einloggen?"
+
+#: ../kano_greeter/user_list.py:41
+msgid "Add Account"
+msgstr "Nutzerkonto hinzufügen"
+
+#: ../kano_greeter/user_list.py:59
+msgid "Are you sure you want to create a new account?"
+msgstr "Willst Du wirklich ein neues Nutzerkonto anlegen?"
+
+#: ../kano_greeter/user_list.py:68
+msgid "Create"
+msgstr "Anlegen"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,21 @@
 
 from distutils.core import setup
 import setuptools
+import os
+
+def get_locales():
+    locale_dir = 'locale'
+    locales = []
+
+    for dirpath, dirnames, filenames in os.walk(locale_dir):
+        for filename in filenames:
+            locales.append(
+                (os.path.join('/usr/share', dirpath, filename),
+                 [os.path.join(dirpath, filename)])
+            )
+
+    return locales
+
 
 setup(name='Kano Greeter',
       version='1.0',
@@ -14,8 +29,7 @@ setup(name='Kano Greeter',
       package_data={'kano_greeter': ['media/css/*']},
       data_files=[
           ('/usr/share/kano-greeter/wallpapers', setuptools.findall('wallpapers')),
-          ('/usr/share/locale', setuptools.findall('locale')),
           ('/usr/share/xgreeters', ['config/kano-greeter.desktop']),
           ('/var/lib/lightdm', ['config/.kdeskrc'])
-      ]
+      ] + get_locales()
      )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name='Kano Greeter',
       package_data={'kano_greeter': ['media/css/*']},
       data_files=[
           ('/usr/share/kano-greeter/wallpapers', setuptools.findall('wallpapers')),
+          ('/usr/share/locale', setuptools.findall('locale')),
           ('/usr/share/xgreeters', ['config/kano-greeter.desktop']),
           ('/var/lib/lightdm', ['config/.kdeskrc'])
       ]


### PR DESCRIPTION
This adds translation hooks to the `kano-greeter` python code.

![kano-greeter](https://cloud.githubusercontent.com/assets/1705654/6245315/9aace50a-b75d-11e4-9c09-0151711bfdc0.png)

(Still not building my own packages, so I didn't test if the change in `setup.py` will tell distutils to correctly install the locale file, sorry. Please test this.)