### PR TITLE
Adding a new view to create a new user based on Kano World account

### DIFF
--- a/bin/kano-greeter-account
+++ b/bin/kano-greeter-account
@@ -1,8 +1,8 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 
 # kano-greeter-account
 #
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 # Script to create a local Unix user account and force password
@@ -19,6 +19,7 @@ import sys
 
 from kano.utils import enforce_root, run_cmd
 from kano_init.user import user_exists
+from kano.logging import logger
 
 def create_user(username, password):
     DEFAULT_USER_GROUPS = "tty,adm,dialout,cdrom,audio,users,sudo,video,games," + \
@@ -72,7 +73,7 @@ if __name__ == '__main__':
         username=sys.argv[1]
         password=sys.argv[2]
     else:
-        print 'Syntax: kano-greeter-account <username> <password>'
+        logger.error('invalid parameters - syntax: kano-greeter-account <username> <password>')
         sys.exit(1)
 
     # Create local user and force the password

--- a/bin/kano-greeter-account
+++ b/bin/kano-greeter-account
@@ -9,6 +9,10 @@
 # Called from Kano Greeter UI via sudo.
 #
 # TODO: This tool is temporary until kano-init provides a sudoable equivalent approach
+# Return codes:
+#    0=new account created successfully
+#    1=account already exists - password has been forced
+#    2=could not create new account
 #
 
 import sys
@@ -22,8 +26,8 @@ def create_user(username, password):
 
     # User already exists, force password and stop here
     if user_exists(username):
-        forced=force_password(username, password)
-	return 1
+        force_password(username, password)
+        return 1
 
     # Add the new Unix user on the system
     umask_override = '0077'
@@ -36,7 +40,7 @@ def create_user(username, password):
     if not force_password(username, password):
         # Cannot force a password, login would not succeed: so rollback
         delete_user(username)
-        return False
+        return 2
 
     # Add the new user to all necessary groups
     cmd = "usermod -G '{}' {}".format(DEFAULT_USER_GROUPS, username)
@@ -74,6 +78,7 @@ if __name__ == '__main__':
     # Create local user and force the password
     try:
         rc=create_user(username, password)
-        sys.exit(rc)
     except:
-        sys.exit(2)
+        rc=2
+
+    sys.exit(rc)

--- a/bin/kano-greeter-account
+++ b/bin/kano-greeter-account
@@ -1,0 +1,79 @@
+#! /usr/bin/python
+
+# kano-greeter-account
+#
+# Copyright (C) 2014 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# Script to create a local Unix user account and force password
+# Called from Kano Greeter UI via sudo.
+#
+# TODO: This tool is temporary until kano-init provides a sudoable equivalent approach
+#
+
+import sys
+
+from kano.utils import enforce_root, run_cmd
+from kano_init.user import user_exists
+
+def create_user(username, password):
+    DEFAULT_USER_GROUPS = "tty,adm,dialout,cdrom,audio,users,sudo,video,games," + \
+                          "plugdev,input,kanousers"    
+
+    # User already exists, force password and stop here
+    if user_exists(username):
+        forced=force_password(username, password)
+	return 1
+
+    # Add the new Unix user on the system
+    umask_override = '0077'
+    cmd = "useradd -m -K UMASK={} -s /bin/bash {}".format(umask_override, username)
+    _, _, rv = run_cmd(cmd)
+    if rv:
+        return 2
+
+    # Force the account password
+    if not force_password(username, password):
+        # Cannot force a password, login would not succeed: so rollback
+        delete_user(username)
+        return False
+
+    # Add the new user to all necessary groups
+    cmd = "usermod -G '{}' {}".format(DEFAULT_USER_GROUPS, username)
+    _, _, rv = run_cmd(cmd)
+    if rv==0:
+       return 0
+    else:
+       return 2
+
+
+def force_password(username, password):
+    cmd = "echo '{}:{}' | chpasswd".format(username, password)
+    _, _, rv = run_cmd(cmd)
+    return (rv==0)
+
+
+def delete_user(username):
+    # kill all process from the user
+    run_cmd("killall -KILL -u {}".format(username))
+    _, _, rv = run_cmd_log("userdel -r {}".format(username))
+    return (rv==0)
+
+
+if __name__ == '__main__':
+
+    # Validate and collect command line options
+    enforce_root('You must be root to use {}'.format(sys.argv[0]))
+    if len(sys.argv) > 2:
+        username=sys.argv[1]
+        password=sys.argv[2]
+    else:
+        print 'Syntax: kano-greeter-account <username> <password>'
+        sys.exit(1)
+
+    # Create local user and force the password
+    try:
+        rc=create_user(username, password)
+        sys.exit(rc)
+    except:
+        sys.exit(2)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-greeter (1.0-2) unstable; urgency=low
+
+  * Added functionality to synchronize a Kano World account.
+
+ -- Team Kano <dev@kano.me>  Thu, 16 Apr 2015 18:16:29 +0100
+
 kano-greeter (1.0-1) unstable; urgency=low
 
   * Initial release.

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext
 Package: kano-greeter
 Architecture: all
 Depends: ${misc:Depends}, kdesk, kano-toolset (>= 1.2-5), gir1.2-gtk-3.0,
-         gir1.2-lightdm-1, kano-init
+         gir1.2-lightdm-1, kano-init, kano-profile
 Replaces: kano-desktop (<< 1.1-4.20141110)
 Breaks: kano-desktop (<< 1.1-4.20141110)
 Description: Python greeter for Kano OS

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,6 +18,9 @@ case "$1" in
         # Allow the greeter to run kano-init
         sed -i '$a%lightdm    ALL=(root) NOPASSWD: /usr/bin/kano-init' "$kano_init_sudoers"
 
+        # Allow the greeter to run kano-greeter-account for Kano World sync
+        sed -i '$a%lightdm    ALL=(root) NOPASSWD: /usr/bin/kano-greeter-account' "$kano_init_sudoers"
+
         # Fix permisssions so that lightdm can start the greeter (this actually seems to be a bug in lightm)
         chown lightdm:lightdm /var/lib/lightdm
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -15,7 +15,7 @@ case "$1" in
         # Revert to the default greeter
         sed -i 's/^\s*\(greeter-session\=\).*/\1lightdm-greeter/' "$lightdm_config"
 
-        # Remove LightDM access to kano-init
+        # Remove LightDM access to kano-init and kano-greeter-account
         sed -i /^%lightdm/d "$kano_init_sudoers"
 
         ;;

--- a/kano_greeter/greeter_window.py
+++ b/kano_greeter/greeter_window.py
@@ -19,6 +19,7 @@ from kano.gtk3.buttons import OrangeButton
 
 from kano_greeter.user_list import UserList
 from kano_greeter.password_view import PasswordView
+from kano_greeter.newuser_view import NewUserView
 
 
 class GreeterWindow(ApplicationWindow):
@@ -81,6 +82,12 @@ class GreeterWindow(ApplicationWindow):
         self.set_main(password_view)
         self.top_bar.enable_prev()
         password_view.grab_focus()
+
+    def go_to_newuser(self):
+        newuser_view = NewUserView()
+        self.set_main(newuser_view)
+        self.top_bar.enable_prev()
+        newuser_view.grab_focus()
 
     def _back_cb(self, event, button):
         self.go_to_users()

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -37,12 +37,12 @@ class NewUserView(Gtk.Grid):
         self.sync_cmd = 'su - {username} -c "/usr/bin/kano-sync --sync -s"'
         self.sync_restore_cmd = 'su - {username} -c "/usr/bin/kano-sync --restore -s"'
 
-        title = Heading(_('Create new user'),
-                        _('Synchronize your Kano World\n' \
-                          'account, or create a new one.'))
+        title = Heading(_('Add new account'),
+                        _('Synchronize a Kano World\n' \
+                          'user, or create a new account.'))
 
         self.attach(title.container, 0, 0, 1, 1)
-        self.label = Gtk.Label("Use your Kano World email account")
+        self.label = Gtk.Label("Use your Kano World user")
         self.label.get_style_context().add_class('login')
         self.attach(self.label, 0, 1, 1, 1)
 
@@ -158,26 +158,23 @@ class NewUserView(Gtk.Grid):
         else:
             # We are authenticated to Kano World: proceed with forcing local user
             try:
-                # TODO: Call sudoed script to create the user and force password
-                # self.unix_username, self.unix_password
                 createuser_cmd='sudo /usr/bin/kano-greeter-account {} {}'.format(self.unix_username, self.unix_password)
                 _, _, rc = run_cmd(createuser_cmd)
                 if rc==0:
-                    # User created correctly, synchronize
+                    logger.debug('Local user created correctly, synchronizing: {}'.format(self.unix_username))
                     run_cmd(self.sync_cmd.format(username=self.unix_username))
                     run_cmd(self.sync_cmd.format(username=self.unix_username))
                     run_cmd(self.sync_restore_cmd.format(username=self.unix_username))
                 elif rc==1:
-                    # User already exists, synchronize
-                    logger.debug('Local user already exists, synchronizing: {} - {}'.format(self.unix_username, reason))
+                    logger.debug('Local user already exists, synchronizing: {}'.format(self.unix_username))
                     run_cmd(self.sync_cmd.format(username=self.unix_username))
                 created=True
             except:
                 created=False
 
             if not created:
-                logger.debug('Error creating new user: {}'.format(self.unix_username))
-                self._error_message_box(title, 'Could not create local user')
+                logger.debug('Error creating new local user: {}'.format(self.unix_username))
+                self._error_message_box(title, _("Could not create local user"))
                 return
 
             # Tell Lidghtdm to proceed with login session using the new user

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -2,8 +2,11 @@
 
 # password_view.py
 #
-# Copyright (C) 2014 Kano Computing Ltd.
+# Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This view allows to authenticate a Kano World account and create a synchroznied local user.
+# Additionally, an option to create a new account via kano-init on the next system boot.
 #
 
 from gi.repository import Gtk

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+# password_view.py
+#
+# Copyright (C) 2014 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+
+from gi.repository import Gtk
+from gi.repository import LightDM
+
+import os
+
+from kano.logging import logger
+from kano.gtk3.buttons import KanoButton, OrangeButton
+from kano.gtk3.heading import Heading
+from kano.gtk3.kano_dialog import KanoDialog
+
+from kano_greeter.last_user import set_last_user
+
+from kano_world.functions import login as kano_world_authenticate
+
+
+class NewUserView(Gtk.Grid):
+    greeter = LightDM.Greeter()
+
+    def __init__(self):
+        Gtk.Grid.__init__(self)
+
+        self.get_style_context().add_class('password')
+        self.set_row_spacing(5)
+
+        self._reset_greeter()
+
+        title = Heading(_('Create new user'),
+                        _('Synchronize your Kano World\n' \
+                          'account, or create a new one.'))
+
+        self.attach(title.container, 0, 0, 1, 1)
+        self.label = Gtk.Label("Use your Kano World email account")
+        self.label.get_style_context().add_class('login')
+        self.attach(self.label, 0, 1, 1, 1)
+
+        self.username = Gtk.Entry()
+        self.username.set_alignment(0.5)
+        self.attach(self.username, 0, 2, 1, 1)
+
+        self.password = Gtk.Entry()
+        self.password.set_visibility(False)
+        self.password.set_alignment(0.5)
+        self.attach(self.password, 0, 3, 1, 1)
+
+        self.login_btn = KanoButton(_('Login & Synchronize'))
+        self.login_btn.connect('clicked', self._btn_login_pressed)
+        self.attach(self.login_btn, 0, 4, 1, 1)
+
+        self.newuser_btn = KanoButton(_('Create new user (reboot)'))
+        self.newuser_btn.connect('clicked', self._new_user_reboot)
+        self.attach(self.newuser_btn, 0, 5, 1, 1)
+
+    def _new_user_reboot(self, event=None, button=None):
+        '''
+        Schedules kano-init to create a new user from scracth on next reboot,
+        then performs the actual reboot
+        '''
+        confirm = KanoDialog(
+            title_text = _('Are you sure you want to create a new account?'),
+            description_text = _('A reboot will be required'),
+            button_dict = [
+                {
+                    'label': _('Cancel').upper(),
+                    'color': 'red',
+                    'return_value': False
+                    },
+                {
+                    'label': _('Create').upper(),
+                    'color': 'green',
+                    'return_value': True
+                    }
+                ])
+        confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        
+        if confirm.run():
+            os.system("sudo kano-init newuser")
+            LightDM.restart()
+
+    def _reset_greeter(self):
+        NewUserView.greeter = NewUserView.greeter.new()
+        NewUserView.greeter.connect_sync()
+
+        # connect signal handlers to LightDM
+        NewUserView.greeter.connect('show-prompt', self._send_password_cb)
+        NewUserView.greeter.connect('authentication-complete',
+                                    self._authentication_complete_cb)
+        NewUserView.greeter.connect('show-message', self._auth_error_cb)
+
+    def _btn_login_pressed(self, event=None, button=None):
+        '''
+        Authenticates against Kano World. If successful synchronizes to a local
+        Unix account, and tells lightdm to go forward with local a login.
+        '''
+
+        logger.debug('Synchronizing Kano World account')
+        self.login_btn.start_spinner()
+
+        loggedin=False
+        reason=''
+
+        try:
+            username=self.username.get_text()
+            password=self.password.get_text()
+            logger.debug('Authenticating user: {} to Kano World'.format(username))
+            (loggedin, reason)=kano_world_authenticate(username, password)
+            logger.debug('Kano World auth response: {} - {}'.format(loggedin, reason))
+        except Exception as e:
+            reason=str(e)
+            logger.debug('Kano World auth Exception: {}'.format(reason))
+            pass
+
+        # Authentication failed, show error message and return to dialog
+        # Note: title is localized, whereas server response text is not
+        if not loggedin:
+            errormsg=KanoDialog(title_text = _('Failed to authenticate to Kano World'),
+                                description_text=reason,
+                                button_dict= [
+                                    {
+                                        'label': _('Ok').upper(),
+                                        'color': 'red',
+                                        'return_value': True
+                                    }])
+
+            errormsg.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+            errormsg.run()
+            self.login_btn.stop_spinner()
+            self.password.set_text('')
+            return
+
+        # TODO: We are authenticated: create unix account and force a LightDM login
+
+        #NewUserView.greeter.authenticate(self.user)
+        #if PasswordView.greeter.get_is_authenticated():
+        #    logger.debug('User is already authenticated, starting session')
+        #    start_session()
+
+    def _send_password_cb(self, _greeter, text, prompt_type):
+        logger.debug('Need to show prompt: {}'.format(text))
+        if _greeter.get_in_authentication():
+            logger.debug('Sending password to LightDM')
+            _greeter.respond(self.password.get_text())
+
+    def _authentication_complete_cb(self, _greeter):
+        logger.debug('Authentication process is complete')
+
+        if not _greeter.get_is_authenticated():
+            logger.warn('Could not authenticate user {}'.format(self.user))
+            self._auth_error_cb(_('Incorrect password (The default is "kano")'))
+
+            return
+
+        logger.info(
+            'The user {} is authenticated. Starting LightDM X Session'
+            .format(self.user))
+
+        set_last_user(self.user)
+
+        if not _greeter.start_session_sync('lightdm-xsession'):
+            logger.error('Failed to start session')
+        else:
+            logger.info('Login failed')
+
+    def _auth_error_cb(self, text, message_type=None):
+        logger.info('There was an error logging in: {}'.format(text))
+
+        win = self.get_toplevel()
+        win.go_to_users()
+
+        error = KanoDialog(title_text=_('Error Logging In'),
+                           description_text=text,
+                           parent_window=self.get_toplevel())
+        error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        error.run()
+
+    def grab_focus(self):
+        self.username.grab_focus()

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -19,6 +19,20 @@ from kano.gtk3.kano_dialog import KanoDialog
 
 from kano_greeter.last_user import get_last_user
 
+class KanoUserList(LightDM.UserList):
+    def __init__(self):
+        LightDM.UserList.__init__(self)
+
+    # Looks like LightDM.UserList declares the below methods
+    # as Pure Virtual - failure to implement them will crash the app
+    def do_user_added(self, user):
+        pass
+    def do_user_changed(self, user):
+        pass
+    def do_user_removed(self, user):
+        pass
+
+
 class UserList(ScrolledWindow):
     HEIGHT = 300
     WIDTH = 250
@@ -47,10 +61,15 @@ class UserList(ScrolledWindow):
 
     def _populate(self):
         # Populate list
-        user_list = LightDM.UserList()
+        user_list = KanoUserList()
+        user_list.thaw_notify()
         for user in user_list.get_users():
             logger.debug('adding user {}'.format(user.get_name()))
             self.add_item(user.get_name())
+
+        # Destroying the class right now, otherwise the user add/del/modify
+        # signals are not sent correctly and the app crashes
+        del(user_list)
 
     def add_item(self, username):
         user = User(username)

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -58,29 +58,10 @@ class UserList(ScrolledWindow):
         if username == self.last_username:
             user.grab_focus()
 
-    @staticmethod
-    def add_account(*args):
-        confirm = KanoDialog(
-            title_text = _('Are you sure you want to create a new account?'),
-            description_text = _('A reboot will be required'),
-            button_dict = [
-                {
-                    'label': _('Cancel').upper(),
-                    'color': 'red',
-                    'return_value': False
-                },
-                {
-                    'label': _('Create').upper(),
-                    'color': 'green',
-                    'return_value': True
-                }
-            ])
-        confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-
-        if confirm.run():
-            os.system("sudo kano-init newuser")
-            LightDM.restart()
-
+    def add_account(self, control):
+        logger.debug('opening new user dialog')
+        win = self.get_toplevel()
+        win.go_to_newuser()
 
 
 class User(KanoButton):
@@ -97,4 +78,3 @@ class User(KanoButton):
         logger.debug('user {} selected'.format(self.username))
         win = self.get_toplevel()
         win.go_to_password(self.username)
-

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -41,7 +41,7 @@ class KanoUserList:
                 # This is an interactive user created by Kano
                 interactive_users.append(user.pw_name)
 
-        return interactive_users
+        return sorted(interactive_users, reverse=False)
 
 
 class UserList(ScrolledWindow):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='Kano Greeter',
       author_email='dev@kano.me',
       url='https://github.com/KanoComputing/kano-greeter',
       packages=['kano_greeter'],
-      scripts=['bin/kano-greeter'],
+      scripts=['bin/kano-greeter', 'bin/kano-greeter-account'],
       package_data={'kano_greeter': ['media/css/*']},
       data_files=[
           ('/usr/share/kano-greeter/wallpapers', setuptools.findall('wallpapers')),


### PR DESCRIPTION
 * The add account option will open a new dialog with login credentials
 * The dialog has 2 buttons: login to Kano World, create a new account via reboot
 * The login authenticates against Kano World, gives error message if failure