### PR TITLE
Fix username truncation when doing 'Login & Sync'

### DIFF
--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -154,7 +154,7 @@ class NewUserView(Gtk.Grid):
         self.unix_password=self.password.get_text()
         self.unix_username=self.username.get_text()
         atsign=self.unix_username.find('@')
-        if atsign:
+        if atsign != -1:
             # For if we are in "staging" mode (see /etc/kano-world.conf)
             self.unix_username=self.unix_username[:atsign]
 


### PR DESCRIPTION
KanoComputing/peldins#1874
The username was getting its last character stripped because the
function to strip off the domain of the entered e-mail address would run
even if the address didn't contain a domain. Fix this by correcting the
check before stripping.

cc @skarbat 