### PR TITLE
i18n: Fix locale install path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_locales():
     for dirpath, dirnames, filenames in os.walk(locale_dir):
         for filename in filenames:
             locales.append(
-                (os.path.join('/usr/share', dirpath, filename),
+                (os.path.join('/usr/share', dirpath),
                  [os.path.join(dirpath, filename)])
             )
 


### PR DESCRIPTION
The compiled locale (`.mo`) files need to be installed to
`/usr/share/locale/<locale>/LC_MESSAGES/<app_name>.mo` but they were
getting installed into a subdirectory rather than the correct one.

cc @pazdera @convolu 