### PR TITLE
18n: Use the kano-i18n library for i18n init

### DIFF
--- a/bin/kano-greeter
+++ b/bin/kano-greeter
@@ -9,7 +9,6 @@
 from gi.repository import Gtk, GObject
 import os
 import sys
-import gettext
 
 from kano.gtk3.apply_styles import apply_styling_to_screen
 
@@ -22,7 +21,8 @@ if __name__ == '__main__' and __package__ is None:
     else:
         LOCALE_PATH = None
 
-gettext.install('kano-greeter', LOCALE_PATH, unicode=1)
+import kano_i18n.init
+kano_i18n.init.install('kano-greeter', LOCALE_PATH)
 
 from kano.logging import logger
 from kano_greeter.paths import CSS_PATH

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext
 Package: kano-greeter
 Architecture: all
 Depends: ${misc:Depends}, kdesk, kano-toolset (>= 1.2-5), gir1.2-gtk-3.0,
-         gir1.2-lightdm-1, kano-init, kano-profile
+         gir1.2-lightdm-1, kano-init, kano-profile, kano-i18n
 Replaces: kano-desktop (<< 1.1-4.20141110)
 Breaks: kano-desktop (<< 1.1-4.20141110)
 Description: Python greeter for Kano OS


### PR DESCRIPTION
Instead of each package handling i18n initialisation independently, use
the `kano-i18n` library.

cc @pazdera @convolu 