### PR TITLE
Fixes for #1448 and #1568

### DIFF
--- a/kano_greeter/greeter_window.py
+++ b/kano_greeter/greeter_window.py
@@ -55,13 +55,6 @@ class GreeterWindow(ApplicationWindow):
         self.top_bar.set_size_request(self.WIDTH, -1)
         self.grid.attach(self.top_bar, 0, 0, 3, 1)
 
-        self.shutdown_btn = OrangeButton(_('Shutdown'))
-        self.shutdown_btn.connect('clicked', self.shutdown)
-        align = Gtk.Alignment(xalign=1.0,
-                              xscale=0.0)
-        align.add(self.shutdown_btn)
-        self.grid.attach(align, 1, 2, 1, 1)
-
         self.grid.attach(Gtk.Label(), 0, 3, 3, 1)
 
         self.top_bar.set_prev_callback(self._back_cb)
@@ -130,22 +123,3 @@ class GreeterWindow(ApplicationWindow):
     def _back_cb(self, event, button):
         self.go_to_users()
 
-    @staticmethod
-    def shutdown(*args):
-        confirm = KanoDialog(title_text = _('Are you sure you want to shut down?'),
-                             button_dict= [
-                                {
-                                    'label': _('Cancel').upper(),
-                                    'color': 'red',
-                                    'return_value': False
-                                },
-                                {
-                                    'label': _('OK').upper(),
-                                    'color': 'green',
-                                    'return_value': True
-                                }
-                             ])
-        confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-
-        if confirm.run():
-            LightDM.shutdown()

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -198,10 +198,15 @@ class NewUserView(Gtk.Grid):
             # Tell Lidghtdm to proceed with login session using the new user
             # We bind LightDM at this point only, this minimizes the number of attempts
             # to bind the Greeter class to a view, which he does not like quite well.
-            self._reset_greeter()
-            self.greeter.authenticate(self.unix_username)
-            if self.greeter.get_is_authenticated():
-                logger.debug('User is already authenticated, starting session')
+            logger.debug('Scheduling lightdm authentication in math thread')
+            GObject.idle_add(self._auth_call)
+
+    def _auth_call(self):
+        logger.debug('Starting lightdm authentication')
+        self._reset_greeter()
+        self.greeter.authenticate(self.unix_username)
+        if self.greeter.get_is_authenticated():
+            logger.debug('User is already authenticated, starting session')
 
     def _send_password_cb(self, _greeter, text, prompt_type):
         logger.debug('Need to show prompt: {}'.format(text))


### PR DESCRIPTION
This PR removes the shutdown button from the account window [peldins#1448](https://github.com/KanoComputing/peldins/issues/1448) and fixes a lockup when creating a local account by synchronising from a kano world account.

@skarbat  Moving the greeter call from the thread seems to fix the issue.

