### PR TITLE
Login to kano world automatically when creating new user

### DIFF
--- a/bin/kano-greeter-account
+++ b/bin/kano-greeter-account
@@ -15,19 +15,68 @@
 #    2=could not create new account
 #
 
+import os
 import sys
 
 from kano.utils import enforce_root, run_cmd
 from kano_init.user import user_exists
 from kano.logging import logger
 
-def create_user(username, password):
+
+def skip_init_flow(username):
+    '''
+    Tell Kano init-flow that this user does not need to go
+    through the initial interactive setup stage. Returns True on success
+    '''
+    init_flow_first_boot='/home/{}/.kano-settings/first_boot'.format(username)
+
+    # create directory if needed, control file, and set file ownership to user
+    cmd = "mkdir -p {} ; touch {} ; chown -R {}:{} {}".format(
+        os.path.dirname(init_flow_first_boot), init_flow_first_boot,
+        username, username, os.path.dirname(init_flow_first_boot))
+
+    _, _, rv = run_cmd(cmd)
+    if rv:
+        logger.error('error creating init_flow skip boot file {} rc={}'.format(init_flow_first_boot, rv))
+
+    return (rv == 0)
+
+
+def login_kano_world(unix_username, world_username, world_password):
+    '''
+    Impersonates as unix_username, attempts a login into Kano World
+    using world_username and world_password credentials.
+    Finally it synchronizes World data locally. Returns True if Kano World login succeeds
+    '''
+    cmd_world_login='su - {} -c \"python -c \\"from kano_world.functions import login; ' \
+        'print login(\'{}\', \'{}\')\\"\"'.format(
+        unix_username, world_username, password)
+
+    r, e, rv = run_cmd(cmd_world_login)
+    if rv:
+        logger.error('Error authenticating to kano world rc={} response {} errors {}'.format(rv, r, e))
+
+    sync_cmd = 'su - {} -c "/usr/bin/kano-sync --sync -s"'.format(unix_username)
+    sync_restore_cmd = 'su - {} -c "/usr/bin/kano-sync --restore -s"'.format(unix_username)
+        
+    _, _, rc1 = run_cmd(sync_cmd)
+    _, _, rc2 = run_cmd(sync_cmd)
+    _, _, rc3 = run_cmd(sync_restore_cmd)
+
+    logger.debug('Kano world synchronization steps rc1={} rc2={} rc3={}'.format(rc1, rc2, rc3))
+
+    return (rv == 0)
+
+
+def create_user(username, password, world_username):
     DEFAULT_USER_GROUPS = "tty,adm,dialout,cdrom,audio,users,sudo,video,games," + \
                           "plugdev,input,kanousers"    
 
     # User already exists, force password and stop here
     if user_exists(username):
         force_password(username, password)
+        skip_init_flow(username)
+        login_kano_world(username, world_username, password)
         return 1
 
     # Add the new Unix user on the system
@@ -46,6 +95,11 @@ def create_user(username, password):
     # Add the new user to all necessary groups
     cmd = "usermod -G '{}' {}".format(DEFAULT_USER_GROUPS, username)
     _, _, rv = run_cmd(cmd)
+
+    # Tell init-flow to skip interactive setup for this user
+    skip_init_flow(username)
+    login_kano_world(username, world_username, password)
+
     if rv==0:
        return 0
     else:
@@ -69,16 +123,17 @@ if __name__ == '__main__':
 
     # Validate and collect command line options
     enforce_root('You must be root to use {}'.format(sys.argv[0]))
-    if len(sys.argv) > 2:
+    if len(sys.argv) > 3:
         username=sys.argv[1]
         password=sys.argv[2]
+        world_username=sys.argv[3]
     else:
-        logger.error('invalid parameters - syntax: kano-greeter-account <username> <password>')
+        logger.error('invalid parameters - syntax: kano-greeter-account <username> <password> <world_username>')
         sys.exit(1)
 
     # Create local user and force the password
     try:
-        rc=create_user(username, password)
+        rc=create_user(username, password, world_username)
     except:
         rc=2
 


### PR DESCRIPTION
 * Once a user is authenticated to kano world, do a login request from the script
 * Also moved the synchronization steps to the external script, as they require broad sudo perms
 * Fixed a usability issue: disabling buttons while a synchronization is taking place
 * Telling kano-init-flow to avoid going through the initial boot stage, so a direct desktop login proceeds
