### PR TITLE
Fixes for username and cached password issues

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -21,6 +21,9 @@ case "$1" in
         # Allow the greeter to run kano-greeter-account for Kano World sync
         sed -i '$a%lightdm    ALL=(root) NOPASSWD: /usr/bin/kano-greeter-account' "$kano_init_sudoers"
 
+        # Allow users to switch to virtual console terminals from the greeter
+        sed -i '$a%lightdm    ALL=(root) NOPASSWD: /bin/chvt' "$kano_init_sudoers"
+
         # Fix permisssions so that lightdm can start the greeter (this actually seems to be a bug in lightm)
         chown lightdm:lightdm /var/lib/lightdm
 

--- a/kano_greeter/media/css/kano-greeter.css
+++ b/kano_greeter/media/css/kano-greeter.css
@@ -1,3 +1,4 @@
 GtkLabel.login {
     font: Bariol Bold 13;
+    color: #6e6e6e;
 }

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -257,4 +257,9 @@ class NewUserView(Gtk.Grid):
         error.run()
 
     def grab_focus(self):
+        '''
+        Clear username and password previous text, and gain focus.
+        '''
+        self.username.set_text('')
+        self.password.set_text('')
         self.username.grab_focus()

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -31,9 +31,9 @@ class PasswordView(Gtk.Grid):
         self.greeter=greeter
 
         self.user = user
-        title = self._set_title()
+        self.title = self._set_title()
 
-        self.attach(title.container, 0, 0, 1, 1)
+        self.attach(self.title.container, 0, 0, 1, 1)
         self.label = Gtk.Label(user)
         self.label.get_style_context().add_class('login')
         self.attach(self.label, 0, 1, 1, 1)
@@ -55,11 +55,22 @@ class PasswordView(Gtk.Grid):
             delete_account_btn.connect('clicked', self.delete_user)
             self.attach(delete_account_btn, 0, 4, 1, 1)
 
-    def _set_title(self):
-        title = Heading(_('{}: Enter your password'.format(self.user)),
-                        _('If you haven\'t changed your password,\n'
-                          'use "kano"'))
-        return title
+    def _set_title(self, create=True):
+        '''
+        Creates a Heading text widget, or updates it
+        with the currently selected username.
+        '''
+
+        # FIXME: Cannot assign NLS token mark to literals below
+        text_title='{}: Enter your password'.format(self.user)
+        text_description='If you haven\'t changed your password,\nuse "kano"'
+        
+        if create:
+            title = Heading(text_title, text_description)
+            return title
+        else:
+            self.title.set_text(text_title, text_description)
+            return self.title
 
     def _reset_greeter(self):
         # connect signal handlers to LightDM
@@ -127,11 +138,14 @@ class PasswordView(Gtk.Grid):
         win.go_to_users()
 
     def grab_focus(self, user):
+        '''
+        Update username title, clear previous password,
+        and give focus to password entry field.
+        '''
         self.user=user
+        self._set_title(create=False)
 
-        # TODO: update the title with the username
-        #self._set_title()
-
+        self.password.set_text('')
         self.password.grab_focus()
 
     def delete_user(self, *args):

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -60,10 +60,8 @@ class PasswordView(Gtk.Grid):
         Creates a Heading text widget, or updates it
         with the currently selected username.
         '''
-
-        # FIXME: Cannot assign NLS token mark to literals below
-        text_title='{}: Enter your password'.format(self.user)
-        text_description='If you haven\'t changed your password,\nuse "kano"'
+        text_title=_('{}: Enter your password').format(self.user)
+        text_description=_('If you haven\'t changed your password,\nuse "kano"')
         
         if create:
             title = Heading(text_title, text_description)


### PR DESCRIPTION
 * Fixed login page username where it was displayed as "None"
 * Fixed the password on the same login window from being cached
 * Granted permissions to switch to virtual terminals from the Greeter