### PR TITLE
Separated logging in with Kano World account

### DIFF
--- a/kano_greeter/greeter_window.py
+++ b/kano_greeter/greeter_window.py
@@ -20,6 +20,7 @@ from kano.gtk3.buttons import OrangeButton
 from kano_greeter.user_list import UserList
 from kano_greeter.password_view import PasswordView
 from kano_greeter.newuser_view import NewUserView
+from kano_greeter.login_with_kw_view import LoginWithKanoWorldView
 
 
 class GreeterWindow(ApplicationWindow):
@@ -31,8 +32,8 @@ class GreeterWindow(ApplicationWindow):
     def __init__(self):
         apply_common_to_screen()
 
-        self.a=self.b=self.c=0
-        self.switching=0
+        self.a = self.b = self.c = 0
+        self.switching = 0
 
         ApplicationWindow.__init__(self, _('Login'), self.WIDTH, self.HEIGHT)
         self.connect("delete-event", Gtk.main_quit)
@@ -43,6 +44,7 @@ class GreeterWindow(ApplicationWindow):
         # Create the two views: one for normal Login, the other to create a new account
         self.password_view = PasswordView(None, self.greeter)
         self.newuser_view = NewUserView(self.greeter)
+        self.login_with_kw_view = LoginWithKanoWorldView(self.greeter)
 
         self.grid = Gtk.Grid()
         self.set_main_widget(self.grid)
@@ -83,7 +85,6 @@ class GreeterWindow(ApplicationWindow):
         self.top_bar.disable_prev()
 
     def go_to_password(self, user):
-        # Called when we switch between views using top-left arrow button
         self.set_main(self.password_view)
         self.top_bar.enable_prev()
 
@@ -93,14 +94,13 @@ class GreeterWindow(ApplicationWindow):
             self.greeter.disconnect(self.c)
 
             self.greeter = GreeterWindow.greeter.new()
-            self.password_view.greeter=self.greeter
-            (self.a,self.b,self.c) = self.password_view._reset_greeter()
-            self.switching=1
-        
+            self.password_view.greeter = self.greeter
+            (self.a, self.b, self.c) = self.password_view._reset_greeter()
+            self.switching = 1
+
         self.password_view.grab_focus(user)
 
     def go_to_newuser(self):
-        # Called when we switch between views using top-left arrow button
         self.set_main(self.newuser_view)
         self.top_bar.enable_prev()
 
@@ -110,15 +110,33 @@ class GreeterWindow(ApplicationWindow):
             self.greeter.disconnect(self.c)
 
             self.greeter = GreeterWindow.greeter.new()
-            self.newuser_view.greeter=self.greeter
+            self.newuser_view.greeter = self.greeter
 
             # FIXME: We do not reset the greeter in the newuser view
             # It will be done only when the local user account has been forced
             # so as to avoid LightDM freezes
-            #(self.a,self.b,self.c) = self.newuser_view._reset_greeter()
-            self.switching=2
+            # (self.a, self.b, self.c) = self.newuser_view._reset_greeter()
+            self.switching = 2
 
-        self.newuser_view.grab_focus()
+    def go_to_login_with_kw(self):
+        self.set_main(self.login_with_kw_view)
+        self.top_bar.enable_prev()
+
+        if not self.switching == 3:
+            self.greeter.disconnect(self.a)
+            self.greeter.disconnect(self.b)
+            self.greeter.disconnect(self.c)
+
+            self.greeter = GreeterWindow.greeter.new()
+            self.login_with_kw_view.greeter = self.greeter
+
+            # FIXME: We do not reset the greeter in the newuser view
+            # It will be done only when the local user account has been forced
+            # so as to avoid LightDM freezes
+            (self.a, self.b, self.c) = self.login_with_kw_view._reset_greeter()
+            self.switching = 3
+
+        self.login_with_kw_view.grab_focus()
 
     def _back_cb(self, event, button):
         self.go_to_users()

--- a/kano_greeter/login_with_kw_view.py
+++ b/kano_greeter/login_with_kw_view.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# login_with_kw_view.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+# This view allows to authenticate a Kano World
+# account and create a synchroznied local user.
+
+
+from gi.repository import Gtk, GObject
+
+from kano.logging import logger
+from kano.gtk3.buttons import KanoButton
+from kano.gtk3.heading import Heading
+from kano.gtk3.kano_dialog import KanoDialog
+
+from kano_greeter.last_user import set_last_user
+
+from kano_world.functions import login as kano_world_authenticate
+from kano.utils import run_cmd
+
+import threading
+
+
+class LoginWithKanoWorldView(Gtk.Grid):
+
+    def __init__(self, greeter):
+        Gtk.Grid.__init__(self)
+
+        self.get_style_context().add_class('password')
+        self.set_row_spacing(12)
+
+        self.greeter = greeter
+
+        title = Heading(_('Login with Kano World'),
+                        _('Enter your Kano World details.'))
+        self.attach(title.container, 0, 0, 1, 1)
+
+        self.username = Gtk.Entry()
+        self.username.set_placeholder_text('username')
+        self.attach(self.username, 0, 1, 1, 1)
+
+        self.password = Gtk.Entry()
+        self.password.set_visibility(False)
+        self.password.set_placeholder_text('password')
+        self.attach(self.password, 0, 2, 1, 1)
+
+        self.login_btn = KanoButton(_('LOGIN'))
+        self.login_btn.connect('clicked', self._btn_login_pressed)
+        self.attach(self.login_btn, 0, 3, 1, 1)
+
+    def _btn_login_pressed(self, event=None, button=None):
+        '''
+        Authenticates against Kano World. If successful synchronizes to a local
+        Unix account, and tells lightdm to go forward with local a login.
+        '''
+        logger.debug('Synchronizing Kano World account')
+        self.login_btn.start_spinner()
+        self.login_btn.set_sensitive(False)
+
+        t = threading.Thread(target=self._thr_login)
+        t.start()
+
+    def _thr_login(self):
+        loggedin = False
+        reason = ''
+
+        # TODO: Disable the "login" button unless these entry fields are non-empty
+        # Collect credentials from the view
+        self.unix_password = self.password.get_text()
+        self.world_username = self.username.get_text()
+        self.unix_username = self.username.get_text()
+        atsign = self.unix_username.find('@')
+        if atsign != -1:
+            # For if we are in "staging" mode (see /etc/kano-world.conf)
+            self.unix_username = self.unix_username[:atsign]
+
+        # Now try to login to Kano World
+        try:
+            logger.debug('Authenticating user: {} to Kano World'.format(self.username.get_text()))
+            (loggedin, reason) = kano_world_authenticate(self.username.get_text(), self.password.get_text())
+            logger.debug('Kano World auth response: {} - {}'.format(loggedin, reason))
+        except Exception as e:
+            reason = str(e)
+            logger.debug('Kano World auth Exception: {}'.format(reason))
+            pass
+
+        if not loggedin:
+            # Kano world auth unauthorized
+            # FIXME: Localizing the below string fails with an exception
+            GObject.idle_add(self._error_message_box, 'Failed to authenticate to Kano World', reason)
+            return
+        else:
+            # We are authenticated to Kano World: proceed with forcing local user
+            rc = -1
+            try:
+                # Create the local unix user, bypass kano-init-flow, login & sync to Kano World
+                createuser_cmd = 'sudo /usr/bin/kano-greeter-account {} {} {}'.format(
+                    self.unix_username, self.unix_password, self.world_username)
+                _, _, rc = run_cmd(createuser_cmd)
+                if rc == 0:
+                    logger.debug('Local user created correctly: {}'.format(self.unix_username))
+                elif rc == 1:
+                    logger.debug('Local user already exists, proceeding with login: {}'.format(self.unix_username))
+
+                created = True
+            except:
+                created = False
+
+            if not created:
+                logger.debug('Error creating new local user: {}'.format(self.unix_username))
+                GObject.idle_add(self._error_message_box, "Could not create local user", rc)
+                return
+
+            # Tell Lidghtdm to proceed with login session using the new user
+            # We bind LightDM at this point only, this minimizes the number of attempts
+            # to bind the Greeter class to a view, which he does not like quite well.
+            logger.debug('Scheduling lightdm authentication in math thread')
+            GObject.idle_add(self._auth_call)
+
+    def _auth_call(self):
+        logger.debug('Starting lightdm authentication')
+        self._reset_greeter()
+        self.greeter.authenticate(self.unix_username)
+        if self.greeter.get_is_authenticated():
+            logger.debug('User is already authenticated, starting session')
+
+    def _reset_greeter(self):
+        # connect signal handlers to LightDM
+        self.cb_one = self.greeter.connect('show-prompt', self._send_password_cb)
+        self.cb_two = self.greeter.connect('authentication-complete',
+                                           self._authentication_complete_cb)
+        self.cb_three = self.greeter.connect('show-message', self._auth_error_cb)
+        self.greeter.connect_sync()
+        return (self.cb_one, self.cb_two, self.cb_three)
+
+    def _send_password_cb(self, _greeter, text, prompt_type):
+        logger.debug('Need to show prompt: {}'.format(text))
+        if _greeter.get_in_authentication():
+            logger.debug('Sending password to LightDM')
+            _greeter.respond(self.unix_password)
+
+    def _authentication_complete_cb(self, _greeter):
+        logger.debug('Authentication process is complete')
+
+        if not _greeter.get_is_authenticated():
+            logger.warn('Could not authenticate user {}'.format(self.unix_username))
+            self._auth_error_cb(_('Incorrect password (The default is "kano")'))
+            return
+
+        logger.info(
+            'The user {} is authenticated. Starting LightDM X Session'
+            .format(self.unix_username))
+
+        set_last_user(self.unix_username)
+
+        if not _greeter.start_session_sync('lightdm-xsession'):
+            logger.error('Failed to start session')
+        else:
+            logger.info('Login failed')
+
+    def _auth_error_cb(self, text, message_type=None):
+        logger.info('There was an error logging in: {}'.format(text))
+
+        win = self.get_toplevel()
+        win.go_to_users()
+
+        self.login_btn.stop_spinner()
+        self.login_btn.set_sensitive(True)
+        self.newuser_btn.set_sensitive(True)
+
+        error = KanoDialog(title_text=_('Error Synchronizing account'),
+                           description_text=text,
+                           parent_window=self.get_toplevel())
+        error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        error.run()
+
+    def _error_message_box(self, title, description):
+        '''
+        Show a standard error message box
+        '''
+        self.login_btn.stop_spinner()
+        self.login_btn.set_sensitive(True)
+
+        errormsg = KanoDialog(title_text=title,
+                              description_text=description,
+                              button_dict=[
+                                  {
+                                      'label': _('OK').upper(),
+                                      'color': 'red',
+                                      'return_value': True
+                                  }])
+
+        errormsg.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        errormsg.run()
+
+        # Clean up password field
+        self.password.set_text('')
+        return
+
+    def grab_focus(self):
+        '''
+        Clear username and password previous text, and gain focus.
+        '''
+        self.username.set_text('')
+        self.password.set_text('')

--- a/kano_greeter/newuser_view.py
+++ b/kano_greeter/newuser_view.py
@@ -5,26 +5,18 @@
 # Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
-# This view allows to authenticate a Kano World account and create a synchroznied local user.
-# Additionally, an option to create a new account via kano-init on the next system boot.
-#
+# An option to create a new account via
+# kano-init on the next system boot.
 
-from gi.repository import Gtk, GObject
+
+from gi.repository import Gtk
 from gi.repository import LightDM
 
 import os
 
-from kano.logging import logger
-from kano.gtk3.buttons import KanoButton, OrangeButton
+from kano.gtk3.buttons import KanoButton
 from kano.gtk3.heading import Heading
 from kano.gtk3.kano_dialog import KanoDialog
-
-from kano_greeter.last_user import set_last_user
-
-from kano_world.functions import login as kano_world_authenticate
-from kano.utils import run_cmd
-
-import threading
 
 
 class NewUserView(Gtk.Grid):
@@ -35,231 +27,48 @@ class NewUserView(Gtk.Grid):
         self.get_style_context().add_class('password')
         self.set_row_spacing(12)
 
-        self.greeter=greeter
+        self.greeter = greeter
 
         title = Heading(_('Add new account'),
-                        _('Synchronize a Kano World\n' \
-                              'user, or create a new account.'))
-
-        self.attach(title.container, 0, 0, 2, 1)
-        self.label = Gtk.Label("Use your Kano World user")
-        self.label.get_style_context().add_class('login')
-        self.attach(self.label, 0, 1, 2, 1)
-
-        # username label and entry field
-        self.user_label = Gtk.Label("Username")
-        self.user_label.get_style_context().add_class('login')
-        self.attach(self.user_label, 0, 2, 1, 1)
-
-        self.username = Gtk.Entry()
-        self.username.set_alignment(0.5)
-        self.attach(self.username, 1, 2, 1, 1)
-
-        # password label and entry field
-        self.pwd_label = Gtk.Label("Password")
-        self.pwd_label.get_style_context().add_class('login')
-        self.attach(self.pwd_label, 0, 3, 1, 1)
-
-        self.password = Gtk.Entry()
-        self.password.set_visibility(False)
-        self.password.set_alignment(0.5)
-        self.attach(self.password, 1, 3, 1, 1)
+                        _('Login with Kano World\n'
+                          'or create a new account.'))
+        self.attach(title.container, 0, 0, 1, 1)
 
         # the 2 push buttons
-        self.login_btn = KanoButton(_('Login & Synchronize'))
-        self.login_btn.connect('clicked', self._btn_login_pressed)
-        self.attach(self.login_btn, 0, 4, 2, 1)
+        self.login_btn = KanoButton(_('Kano World'))
+        self.login_btn.connect('clicked', self._login_button_pressed)
+        self.attach(self.login_btn, 0, 1, 1, 1)
 
-        self.newuser_btn = KanoButton(_('Create new user (reboot)'))
+        self.newuser_btn = KanoButton(_('New Account'))
         self.newuser_btn.connect('clicked', self._new_user_reboot)
-        self.attach(self.newuser_btn, 0, 5, 2, 1)
+        self.attach(self.newuser_btn, 0, 2, 1, 1)
+
+    def _login_button_pressed(self, event=None, button=None):
+        win = self.get_toplevel()
+        win.go_to_login_with_kw()
 
     def _new_user_reboot(self, event=None, button=None):
         '''
-        Schedules kano-init to create a new user from scracth on next reboot,
+        Schedules kano-init to create a new user from scratch on next reboot,
         then performs the actual reboot
         '''
         confirm = KanoDialog(
-            title_text = _('Are you sure you want to create a new account?'),
-            description_text = _('A reboot will be required'),
-            button_dict = [
+            title_text=_('Are you sure you want to create a new account?'),
+            description_text=_('A reboot will be required'),
+            button_dict=[
                 {
                     'label': _('Cancel').upper(),
                     'color': 'red',
                     'return_value': False
-                    },
+                },
                 {
                     'label': _('Create').upper(),
                     'color': 'green',
                     'return_value': True
-                    }
-                ])
+                }
+            ])
         confirm.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        
+
         if confirm.run():
             os.system("sudo kano-init schedule add-user")
             LightDM.restart()
-
-    def _reset_greeter(self):
-        # connect signal handlers to LightDM
-        self.cb_one = self.greeter.connect('show-prompt', self._send_password_cb)
-        self.cb_two = self.greeter.connect('authentication-complete',
-                                           self._authentication_complete_cb)
-        self.cb_three = self.greeter.connect('show-message', self._auth_error_cb)
-        self.greeter.connect_sync()
-        return (self.cb_one, self.cb_two, self.cb_three)
-
-    def _error_message_box(self, title, description):
-        '''
-        Show a standard error message box
-        '''
-        self.login_btn.stop_spinner()
-        self.login_btn.set_sensitive(True)
-        self.newuser_btn.set_sensitive(True)
-
-        errormsg=KanoDialog(title_text=title,
-                            description_text=description,
-                            button_dict= [
-                                {
-                                    'label': _('Ok').upper(),
-                                    'color': 'red',
-                                    'return_value': True
-                                    }])
-
-        errormsg.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        errormsg.run()
-
-        # Clean up password field
-        self.password.set_text('')
-        return
-
-    def _btn_login_pressed(self, event=None, button=None):
-        '''
-        Authenticates against Kano World. If successful synchronizes to a local
-        Unix account, and tells lightdm to go forward with local a login.
-        '''
-        logger.debug('Synchronizing Kano World account')
-        self.login_btn.start_spinner()
-        self.login_btn.set_sensitive(False)
-        self.newuser_btn.set_sensitive(False)
-
-        t = threading.Thread(target=self._thr_login)
-        t.start()
-
-    def _thr_login(self):
-        loggedin=False
-        reason=''
-
-        # TODO: Disable the "login" button unless these entry fields are non-empty
-        # Collect credentials from the view
-        self.unix_password=self.password.get_text()
-        self.world_username=self.username.get_text()
-        self.unix_username=self.username.get_text()
-        atsign=self.unix_username.find('@')
-        if atsign != -1:
-            # For if we are in "staging" mode (see /etc/kano-world.conf)
-            self.unix_username=self.unix_username[:atsign]
-
-        # Now try to login to Kano World
-        try:
-            logger.debug('Authenticating user: {} to Kano World'.format(self.username.get_text()))
-            (loggedin, reason)=kano_world_authenticate(self.username.get_text(), self.password.get_text())
-            logger.debug('Kano World auth response: {} - {}'.format(loggedin, reason))
-        except Exception as e:
-            reason=str(e)
-            logger.debug('Kano World auth Exception: {}'.format(reason))
-            pass
-
-        if not loggedin:
-            # Kano world auth unauthorized
-            # FIXME: Localizing the below string fails with an exception
-            GObject.idle_add(self._error_message_box, 'Failed to authenticate to Kano World', reason)
-            return
-        else:
-            # We are authenticated to Kano World: proceed with forcing local user
-            rc=-1
-            try:
-                # Create the local unix user, bypass kano-init-flow, login & sync to Kano World 
-                createuser_cmd='sudo /usr/bin/kano-greeter-account {} {} {}'.format(
-                    self.unix_username, self.unix_password, self.world_username)
-                _, _, rc = run_cmd(createuser_cmd)
-                if rc==0:
-                    logger.debug('Local user created correctly: {}'.format(self.unix_username))
-                elif rc==1:
-                    logger.debug('Local user already exists, proceeding with login: {}'.format(self.unix_username))
-
-                created=True
-            except:
-                created=False
-
-            if not created:
-                logger.debug('Error creating new local user: {}'.format(self.unix_username))
-                GObject.idle_add(self._error_message_box, "Could not create local user", rc)
-                return
-
-            # Tell Lidghtdm to proceed with login session using the new user
-            # We bind LightDM at this point only, this minimizes the number of attempts
-            # to bind the Greeter class to a view, which he does not like quite well.
-            logger.debug('Scheduling lightdm authentication in math thread')
-            GObject.idle_add(self._auth_call)
-
-    def _auth_call(self):
-        logger.debug('Starting lightdm authentication')
-        self._reset_greeter()
-        self.greeter.authenticate(self.unix_username)
-        if self.greeter.get_is_authenticated():
-            logger.debug('User is already authenticated, starting session')
-
-    def _send_password_cb(self, _greeter, text, prompt_type):
-        logger.debug('Need to show prompt: {}'.format(text))
-        if _greeter.get_in_authentication():
-            logger.debug('Sending password to LightDM')
-            _greeter.respond(self.unix_password)
-
-    def _authentication_complete_cb(self, _greeter):
-        logger.debug('Authentication process is complete')
-
-        if not _greeter.get_is_authenticated():
-            logger.warn('Could not authenticate user {}'.format(self.unix_username))
-            self._auth_error_cb(_('Incorrect password (The default is "kano")'))
-            return
-
-        # New user created and locally authenticated, we are logged in
-        title=_("User {} has been created".format(self.unix_username))
-        description=_("Logging in with the new username: {}".format(self.unix_username))
-        self._error_message_box(title, description)
-
-        logger.info(
-            'The user {} is authenticated. Starting LightDM X Session'
-            .format(self.unix_username))
-
-        set_last_user(self.unix_username)
-
-        if not _greeter.start_session_sync('lightdm-xsession'):
-            logger.error('Failed to start session')
-        else:
-            logger.info('Login failed')
-
-    def _auth_error_cb(self, text, message_type=None):
-        logger.info('There was an error logging in: {}'.format(text))
-
-        win = self.get_toplevel()
-        win.go_to_users()
-
-        self.login_btn.stop_spinner()
-        self.login_btn.set_sensitive(True)
-        self.newuser_btn.set_sensitive(True)
-
-        error = KanoDialog(title_text=_('Error Synchronizing account'),
-                           description_text=text,
-                           parent_window=self.get_toplevel())
-        error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        error.run()
-
-    def grab_focus(self):
-        '''
-        Clear username and password previous text, and gain focus.
-        '''
-        self.username.set_text('')
-        self.password.set_text('')
-        self.username.grab_focus()

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -61,8 +61,8 @@ class PasswordView(Gtk.Grid):
         with the currently selected username.
         '''
         text_title=_('{}: Enter your password').format(self.user)
-        text_description=_('If you haven\'t changed your password,\nuse "kano"')
-        
+        text_description=_('If you haven\'t changed your\npassword, use "kano"')
+
         if create:
             title = Heading(text_title, text_description)
             return title
@@ -85,7 +85,7 @@ class PasswordView(Gtk.Grid):
 
         self.login_btn.start_spinner()
         Gtk.main_iteration_do(True)
-        
+
         self.greeter.authenticate(self.user)
 
         if self.greeter.get_is_authenticated():


### PR DESCRIPTION
Among copy changes, logging in with Kano World was moved to another window making it
more clear as to what was about to happen. Now, when clicking on 'Add a new user' a
window with 2 buttons pops up from which you choose whether to login with Kano World
account or create a brand new account. The former option brings up a new view with an
entry for username and one for password. The entries now use a placeholder text instead
of labels separately.

@alex5imon @skarbat 

--
*Greeter Window*

<img width="234" alt="screen shot 2015-10-20 at 15 50 09" src="https://cloud.githubusercontent.com/assets/3577547/10611054/5566e6c6-7742-11e5-8385-11ad79980706.png">

--
*Pressed `Add Account` label*

<img width="236" alt="screen shot 2015-10-20 at 15 50 17" src="https://cloud.githubusercontent.com/assets/3577547/10611056/556ba5a8-7742-11e5-8f11-fa8b812a9ac8.png">

--
*Pressed `Kano World` button*

<img width="235" alt="screen shot 2015-10-20 at 15 50 24" src="https://cloud.githubusercontent.com/assets/3577547/10611055/55685754-7742-11e5-8671-b865a7812732.png">

--
*Pressed `New Account` button*

<img width="312" alt="screen shot 2015-10-20 at 15 50 31" src="https://cloud.githubusercontent.com/assets/3577547/10611057/55701ca0-7742-11e5-8072-0b22c8b4e87a.png">
