### PR TITLE
Updating list of python files.

### DIFF
--- a/po/PYPOTFILES
+++ b/po/PYPOTFILES
@@ -3,3 +3,7 @@
 ../kano_greeter/password_view.py
 ../kano_greeter/user_list.py
 ../kano_greeter/newuser_view.py
+../kano_greeter/__init__.py
+../kano_greeter/last_user.py
+../kano_greeter/login_with_kw_view.py
+../kano_greeter/paths.py


### PR DESCRIPTION
There were some missing files in the list of python files used by the i18n Makefile. We need to keep these up to date so our contributors can see all the strings to be translated.
@radujipa @tombettany 
 