### PR TITLE
Spanish translation for kano-greeter screen flow

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ kano-greeter (2.3.0-0) unstable; urgency=low
 
  -- Team Kano <dev@kano.me>  Tue, 12 Jan 2016 18:16:29 +0100
 
- kano-greeter (1.0-2) unstable; urgency=low
+kano-greeter (1.0-2) unstable; urgency=low
 
   * Added functionality to synchronize a Kano World account.
 

--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0), python-setuptools, gettext
+Build-Depends: debhelper (>=9.0.0), dh-python, python-setuptools, gettext
 
 Package: kano-greeter
 Architecture: all
-Depends: ${misc:Depends}, kdesk, kano-toolset (>= 1.2-5), gir1.2-gtk-3.0,
+Depends: ${misc:Depends}, kdesk, kano-toolset (>= 3.7.0), gir1.2-gtk-3.0,
          gir1.2-lightdm-1, kano-init, kano-profile, kano-i18n
 Replaces: kano-desktop (<< 1.1-4.20141110)
 Breaks: kano-desktop (<< 1.1-4.20141110)

--- a/kano_greeter/__init__.py
+++ b/kano_greeter/__init__.py
@@ -20,4 +20,4 @@ else:
     LOCALE_PATH = None
 
 import kano_i18n.init
-kano_i18n.init.register_domain('kano-profile', LOCALE_PATH)
+kano_i18n.init.register_domain('kano-greeter', LOCALE_PATH)

--- a/kano_greeter/__init__.py
+++ b/kano_greeter/__init__.py
@@ -8,3 +8,16 @@
 
 __author__ = 'Kano Computing Ltd.'
 __email__ = 'dev@kano.me'
+
+import os
+import sys
+
+DIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if DIR_PATH != '/usr':
+    sys.path.insert(1, DIR_PATH)
+    LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+else:
+    LOCALE_PATH = None
+
+import kano_i18n.init
+kano_i18n.init.register_domain('kano-profile', LOCALE_PATH)

--- a/kano_greeter/login_with_kw_view.py
+++ b/kano_greeter/login_with_kw_view.py
@@ -39,12 +39,12 @@ class LoginWithKanoWorldView(Gtk.Grid):
         self.attach(title.container, 0, 0, 1, 1)
 
         self.username = Gtk.Entry()
-        self.username.set_placeholder_text('username')
+        self.username.set_placeholder_text(_('username'))
         self.attach(self.username, 0, 1, 1, 1)
 
         self.password = Gtk.Entry()
         self.password.set_visibility(False)
-        self.password.set_placeholder_text('password')
+        self.password.set_placeholder_text(_('password'))
         self.attach(self.password, 0, 2, 1, 1)
 
         self.login_btn = KanoButton(_('LOGIN'))
@@ -90,7 +90,7 @@ class LoginWithKanoWorldView(Gtk.Grid):
         if not loggedin:
             # Kano world auth unauthorized
             # FIXME: Localizing the below string fails with an exception
-            GObject.idle_add(self._error_message_box, 'Failed to authenticate to Kano World', reason)
+            GObject.idle_add(self._error_message_box, _('Failed to authenticate to Kano World'), reason)
             return
         else:
             # We are authenticated to Kano World: proceed with forcing local user
@@ -99,7 +99,7 @@ class LoginWithKanoWorldView(Gtk.Grid):
                 # Create the local unix user, bypass kano-init-flow, login & sync to Kano World
                 createuser_cmd = 'sudo /usr/bin/kano-greeter-account {} {} {}'.format(
                     self.unix_username, self.unix_password, self.world_username)
-                _, _, rc = run_cmd(createuser_cmd)
+                procout, procerr, rc = run_cmd(createuser_cmd)
                 if rc == 0:
                     logger.debug('Local user created correctly: {}'.format(self.unix_username))
                 elif rc == 1:
@@ -111,7 +111,7 @@ class LoginWithKanoWorldView(Gtk.Grid):
 
             if not created:
                 logger.debug('Error creating new local user: {}'.format(self.unix_username))
-                GObject.idle_add(self._error_message_box, "Could not create local user", rc)
+                GObject.idle_add(self._error_message_box, _('Could not create local user'), rc)
                 return
 
             # Tell Lidghtdm to proceed with login session using the new user

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -19,9 +19,6 @@ from kano.gtk3.kano_dialog import KanoDialog
 from kano_greeter.last_user import set_last_user
 from kano_greeter.user_list import KanoUserList
 
-# Placeholder function to translate encoding only when necessary
-def encode(x): return x.encode('utf-8') if isinstance(x,unicode) else x
-
 class PasswordView(Gtk.Grid):
 
     def __init__(self, user, greeter):
@@ -95,7 +92,7 @@ class PasswordView(Gtk.Grid):
             start_session()
 
     def _send_password_cb(self, _greeter, text, prompt_type):
-        logger.debug('Need to show prompt: {}'.format(text))
+        logger.debug(u'Need to show prompt: {}'.format(text))
 
         if _greeter.get_in_authentication():
             logger.debug('Sending password to LightDM')
@@ -122,7 +119,7 @@ class PasswordView(Gtk.Grid):
             logger.info('Login failed')
 
     def _auth_error_cb(self, text, message_type=None):
-        logger.info('There was an error logging in: {}'.format(encode(text)))
+        logger.info(u'There was an error logging in: {}'.format(text))
 
         self.greeter.cancel_authentication()
 
@@ -202,7 +199,7 @@ class PasswordView(Gtk.Grid):
                 error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
                 error.run()
         except Exception as e:
-            logger.error('Error deleting account {} - {}'.format(self.user, str(e)))
+            logger.error(u'Error deleting account {} - {}'.format(self.user, str(e)))
             error = KanoDialog(title_text = _('Could not delete account {}'.format(self.user)))
             error.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
             error.run()

--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -19,6 +19,8 @@ from kano.gtk3.kano_dialog import KanoDialog
 from kano_greeter.last_user import set_last_user
 from kano_greeter.user_list import KanoUserList
 
+# Placeholder function to translate encoding only when necessary
+def encode(x): return x.encode('utf-8') if isinstance(x,unicode) else x
 
 class PasswordView(Gtk.Grid):
 
@@ -120,7 +122,7 @@ class PasswordView(Gtk.Grid):
             logger.info('Login failed')
 
     def _auth_error_cb(self, text, message_type=None):
-        logger.info('There was an error logging in: {}'.format(text))
+        logger.info('There was an error logging in: {}'.format(encode(text)))
 
         self.greeter.cancel_authentication()
 

--- a/kano_greeter/user_list.py
+++ b/kano_greeter/user_list.py
@@ -99,8 +99,8 @@ class UserListView(Gtk.Grid):
         win.go_to_newuser()
 
     def _btn_shutdown_pressed(self, event=None, button=None):
-        shutdown_dialog = KanoDialog(title_text='Shutting down..',
-                                     description_text='Are you sure you want to shutdown your Kano now?',
+        shutdown_dialog = KanoDialog(title_text=_('Shutting down..'),
+                                     description_text=_('Are you sure you want to shutdown your Kano now?'),
                                      button_dict=[
                                          {
                                              'label': _('Cancel').upper(),

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kano-greeter\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-28 14:15+0200\n"
+"POT-Creation-Date: 2016-09-28 15:34+0200\n"
 "PO-Revision-Date: 2016-09-28 14:16+0200\n"
 "Last-Translator:  <dev@kano.me>\n"
 "Language-Team: Argentinian\n"
@@ -19,67 +19,67 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../kano_greeter/greeter_window.py:38 ../kano_greeter/greeter_window.py:55
-#: ../kano_greeter/password_view.py:46
+#: ../kano_greeter/password_view.py:48
 msgid "Login"
 msgstr "Ingresar"
 
-#: ../kano_greeter/password_view.py:54
+#: ../kano_greeter/password_view.py:56
 msgid "Remove Account"
 msgstr "Eliminar cuenta"
 
-#: ../kano_greeter/password_view.py:63
+#: ../kano_greeter/password_view.py:65
 msgid "{}: Enter your password"
 msgstr "{}: Ingresa tu contraseña"
 
-#: ../kano_greeter/password_view.py:64
+#: ../kano_greeter/password_view.py:66
 msgid ""
 "If you haven't changed your\n"
 "password, use \"kano\""
 msgstr "Si no cambiaste tu contraseña, usa \"kano\""
 
-#: ../kano_greeter/password_view.py:107
+#: ../kano_greeter/password_view.py:109
 #: ../kano_greeter/login_with_kw_view.py:150
 msgid "Incorrect password (The default is \"kano\")"
 msgstr "Contraseña incorrecta (Por defecto es \"kano\")"
 
-#: ../kano_greeter/password_view.py:131
+#: ../kano_greeter/password_view.py:133
 msgid "Error Logging In"
 msgstr "Error en ingreso"
 
-#: ../kano_greeter/password_view.py:157
+#: ../kano_greeter/password_view.py:159
 msgid "Are you sure you want to delete this account?"
 msgstr "Estás seguro que quieres eliminar esta cuenta?"
 
-#: ../kano_greeter/password_view.py:158
+#: ../kano_greeter/password_view.py:160
 msgid "Enter {}'s password - A reboot will be required"
 msgstr "Ingresa la contraseña de {} - Será necesario reiniciar"
 
-#: ../kano_greeter/password_view.py:163 ../kano_greeter/user_list.py:106
+#: ../kano_greeter/password_view.py:165 ../kano_greeter/user_list.py:106
 #: ../kano_greeter/newuser_view.py:60
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../kano_greeter/password_view.py:168
+#: ../kano_greeter/password_view.py:170
 msgid "Ok"
 msgstr "Bien"
 
-#: ../kano_greeter/password_view.py:181
+#: ../kano_greeter/password_view.py:183
 msgid "Please enter the password for user {}"
 msgstr "Por favor ingresa la contraseña del usuario {}"
 
-#: ../kano_greeter/password_view.py:191
+#: ../kano_greeter/password_view.py:193
 msgid "User {} scheduled for removal"
 msgstr "El usuario {} se ha marcado para ser eliminado"
 
-#: ../kano_greeter/password_view.py:192
+#: ../kano_greeter/password_view.py:194
 msgid "Press OK to reboot"
 msgstr "Presiona Bien para reiniciar"
 
-#: ../kano_greeter/password_view.py:199
+#: ../kano_greeter/password_view.py:201
 msgid "Incorrect password for user {}"
 msgstr "Contraseña incorrecta para el usuario {}"
 
-#: ../kano_greeter/password_view.py:204
+#: ../kano_greeter/password_view.py:206
 msgid "Could not delete account {}"
 msgstr "No se pudo eliminar la cuenta {}"
 
@@ -99,6 +99,14 @@ msgstr "Añadir Cuenta"
 msgid "Shutdown"
 msgstr "Apagar"
 
+#: ../kano_greeter/user_list.py:102
+msgid "Shutting down.."
+msgstr "Apagando..."
+
+#: ../kano_greeter/user_list.py:103
+msgid "Are you sure you want to shutdown your Kano now?"
+msgstr "Estás seguro que quieres apagar tu Kano ahora?"
+
 #: ../kano_greeter/user_list.py:111
 msgid "SHUTDOWN"
 msgstr "APAGAR"
@@ -111,7 +119,8 @@ msgstr "Añadir nueva cuenta"
 msgid ""
 "Login with Kano World\n"
 "or create a new account."
-msgstr "Ingresar en Mundo Kano\n"
+msgstr ""
+"Ingresar en Mundo Kano\n"
 "o crear una nueva cuenta"
 
 #: ../kano_greeter/newuser_view.py:38
@@ -142,9 +151,25 @@ msgstr "Ingresar en Mundo Kano"
 msgid "Enter your Kano World details."
 msgstr "Ingresa tu información de acceso a Mundo Kano"
 
+#: ../kano_greeter/login_with_kw_view.py:42
+msgid "username"
+msgstr "usuario"
+
+#: ../kano_greeter/login_with_kw_view.py:47
+msgid "password"
+msgstr "contraseña"
+
 #: ../kano_greeter/login_with_kw_view.py:50
 msgid "LOGIN"
 msgstr "INGRESAR"
+
+#: ../kano_greeter/login_with_kw_view.py:93
+msgid "Failed to authenticate to Kano World"
+msgstr "No se pudo autenticar a Mundo Kano"
+
+#: ../kano_greeter/login_with_kw_view.py:114
+msgid "Could not create local user"
+msgstr "No se pudo crear el usuario local"
 
 #: ../kano_greeter/login_with_kw_view.py:174
 msgid "Error Synchronizing account"

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -1,0 +1,155 @@
+# Spanish translations for kano-greeter package
+# Traducciones al español para el paquete kano-greeter.
+# Copyright (C) 2016 Kano Computing Ltd.
+# This file is distributed under the same license as the kano-greeter package.
+#  <dev@kano.me>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: kano-greeter\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-28 14:15+0200\n"
+"PO-Revision-Date: 2016-09-28 14:16+0200\n"
+"Last-Translator:  <dev@kano.me>\n"
+"Language-Team: Argentinian\n"
+"Language: es_AR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../kano_greeter/greeter_window.py:38 ../kano_greeter/greeter_window.py:55
+#: ../kano_greeter/password_view.py:46
+msgid "Login"
+msgstr "Ingresar"
+
+#: ../kano_greeter/password_view.py:54
+msgid "Remove Account"
+msgstr "Eliminar cuenta"
+
+#: ../kano_greeter/password_view.py:63
+msgid "{}: Enter your password"
+msgstr "{}: Ingresa tu contraseña"
+
+#: ../kano_greeter/password_view.py:64
+msgid ""
+"If you haven't changed your\n"
+"password, use \"kano\""
+msgstr "Si no cambiaste tu contraseña, usa \"kano\""
+
+#: ../kano_greeter/password_view.py:107
+#: ../kano_greeter/login_with_kw_view.py:150
+msgid "Incorrect password (The default is \"kano\")"
+msgstr "Contraseña incorrecta (Por defecto es \"kano\")"
+
+#: ../kano_greeter/password_view.py:131
+msgid "Error Logging In"
+msgstr "Error en ingreso"
+
+#: ../kano_greeter/password_view.py:157
+msgid "Are you sure you want to delete this account?"
+msgstr "Estás seguro que quieres eliminar esta cuenta?"
+
+#: ../kano_greeter/password_view.py:158
+msgid "Enter {}'s password - A reboot will be required"
+msgstr "Ingresa la contraseña de {} - Será necesario reiniciar"
+
+#: ../kano_greeter/password_view.py:163 ../kano_greeter/user_list.py:106
+#: ../kano_greeter/newuser_view.py:60
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../kano_greeter/password_view.py:168
+msgid "Ok"
+msgstr "Bien"
+
+#: ../kano_greeter/password_view.py:181
+msgid "Please enter the password for user {}"
+msgstr "Por favor ingresa la contraseña del usuario {}"
+
+#: ../kano_greeter/password_view.py:191
+msgid "User {} scheduled for removal"
+msgstr "El usuario {} se ha marcado para ser eliminado"
+
+#: ../kano_greeter/password_view.py:192
+msgid "Press OK to reboot"
+msgstr "Presiona Bien para reiniciar"
+
+#: ../kano_greeter/password_view.py:199
+msgid "Incorrect password for user {}"
+msgstr "Contraseña incorrecta para el usuario {}"
+
+#: ../kano_greeter/password_view.py:204
+msgid "Could not delete account {}"
+msgstr "No se pudo eliminar la cuenta {}"
+
+#: ../kano_greeter/user_list.py:59
+msgid "Select Account"
+msgstr "Selecciona la Cuenta"
+
+#: ../kano_greeter/user_list.py:60
+msgid "Log in to which account?"
+msgstr "Ingresar con cual cuenta?"
+
+#: ../kano_greeter/user_list.py:75
+msgid "Add Account"
+msgstr "Añadir Cuenta"
+
+#: ../kano_greeter/user_list.py:79
+msgid "Shutdown"
+msgstr "Apagar"
+
+#: ../kano_greeter/user_list.py:111
+msgid "SHUTDOWN"
+msgstr "APAGAR"
+
+#: ../kano_greeter/newuser_view.py:32
+msgid "Add new account"
+msgstr "Añadir nueva cuenta"
+
+#: ../kano_greeter/newuser_view.py:33
+msgid ""
+"Login with Kano World\n"
+"or create a new account."
+msgstr "Ingresar en Mundo Kano\n"
+"o crear una nueva cuenta"
+
+#: ../kano_greeter/newuser_view.py:38
+msgid "Kano World"
+msgstr "Mundo Kano"
+
+#: ../kano_greeter/newuser_view.py:42
+msgid "New Account"
+msgstr "Nueva Cuenta"
+
+#: ../kano_greeter/newuser_view.py:56
+msgid "Are you sure you want to create a new account?"
+msgstr "Estás seguro que quieres crear una nueva cuenta?"
+
+#: ../kano_greeter/newuser_view.py:57
+msgid "A reboot will be required"
+msgstr "Será necesario un reinicio"
+
+#: ../kano_greeter/newuser_view.py:65
+msgid "Create"
+msgstr "Crear"
+
+#: ../kano_greeter/login_with_kw_view.py:37
+msgid "Login with Kano World"
+msgstr "Ingresar en Mundo Kano"
+
+#: ../kano_greeter/login_with_kw_view.py:38
+msgid "Enter your Kano World details."
+msgstr "Ingresa tu información de acceso a Mundo Kano"
+
+#: ../kano_greeter/login_with_kw_view.py:50
+msgid "LOGIN"
+msgstr "INGRESAR"
+
+#: ../kano_greeter/login_with_kw_view.py:174
+msgid "Error Synchronizing account"
+msgstr "Error sincronizando la cuenta"
+
+#: ../kano_greeter/login_with_kw_view.py:191
+msgid "OK"
+msgstr "BIEN"


### PR DESCRIPTION
Most of the messages are now translated except for:

 - [x] placeholder "username" and "password" in the entry fields
 - [x] error on kano-world login (some need translation marks, others are returned from KW API)

Also, fixed one exception where the local login error message was not utf-8 ready and would freeze the greeter.

@tombettany @radujipa 