### PR TITLE
CI: Utilise package autobuild function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@ import build_deb_pkg
 
 
 stage ('Build') {
-    build_deb_pkg 'kano-greeter', env.BRANCH_NAME, 'scratch'
+    autobuild_repo_pkg 'kano-greeter'
 }


### PR DESCRIPTION
Eliminate the knowledge from the Jenkinsfile of how to do the package
building to allow this to be centralised.

Only to be merged with other changes to avoid unnecessarily causing package updates
cc @skarbat 