### PR TITLE
Clarify call to non-existing start_session API

### DIFF
--- a/kano_greeter/password_view.py
+++ b/kano_greeter/password_view.py
@@ -84,13 +84,10 @@ class PasswordView(Gtk.Grid):
         self.login_btn.start_spinner()
         Gtk.main_iteration_do(True)
 
+        # The call below will simply initiate the login flow.
+        # The greeter library will inform us through callbacks
+        # See: http://web.mit.edu/Source/debathena/config/lightdm-config/debian/debathena-lightdm-greeter
         self.greeter.authenticate(self.user)
-
-        if self.greeter.get_is_authenticated():
-            logger.debug('User is already authenticated, starting session')
-            # FIXME: The line below was randomly spotted with static analysis
-            # and disabled to avoid a traceback. Please investigate.
-            # start_session()
 
     def _send_password_cb(self, _greeter, text, prompt_type):
         logger.debug(u'Need to show prompt: {}'.format(text))


### PR DESCRIPTION
This PR clarifies the function call `start_session`.

Clearly the `start_session` does not exist - confirmed on the PI with logs.
The call to `greeter.authenticate` initiates the login in the background,
it seems to be pointless to ask if the user is logged in right after that.

I've tested this PR on the PI and the greeter logs me in correctly with 2 different users.
